### PR TITLE
Override back button navigation

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient.Android/MainActivity.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient.Android/MainActivity.cs
@@ -17,5 +17,16 @@ namespace RightToAskClient.Droid
             App.Current.On<Xamarin.Forms.PlatformConfiguration.Android>().
                 UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize);
         }
+
+        private int counter = 0;
+        public override void OnBackPressed()
+        {
+            counter++;
+            if (counter >= 2)
+            {
+                base.OnBackPressed(); // removing this call will prevent the user from being able to leave the app by pressing the back button
+                counter = 0;
+            }
+        }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient.Android/MainActivity.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient.Android/MainActivity.cs
@@ -18,6 +18,7 @@ namespace RightToAskClient.Droid
                 UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize);
         }
 
+        /*
         private int counter = 0;
         public override void OnBackPressed()
         {
@@ -27,6 +28,6 @@ namespace RightToAskClient.Droid
                 base.OnBackPressed(); // removing this call will prevent the user from being able to leave the app by pressing the back button
                 counter = 0;
             }
-        }
+        }*/
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml
@@ -33,6 +33,7 @@
             </Style>
             <Style TargetType="ContentPage" ApplyToDerivedTypes="True">
                 <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource WindowBackgroundColor}, Dark={StaticResource WindowBackgroundColorDark}}"></Setter>
+                <Setter Property="Shell.FlyoutBehavior" Value="Disabled"/>
             </Style>
             <!--Specific Styles-->
             <Style x:Key="TurquoiseButton" TargetType="Button">

--- a/RightToAskClient/RightToAskClient/RightToAskClient/RightToAskClient.csproj
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/RightToAskClient.csproj
@@ -77,6 +77,11 @@
     <EmbeddedResource Remove="Views\AuthoritiesRTKCategories.xaml" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Xamarin.Essentials">
+      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Microsoft\Xamarin\NuGet\xamarin.essentials\1.6.1\lib\monoandroid10.0\Xamarin.Essentials.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Compile Update="Resx\AppResources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
@@ -219,6 +219,14 @@ namespace RightToAskClient.ViewModels
                 RegisterPage1 otherUserProfilePage = new RegisterPage1();
                 await App.Current.MainPage.Navigation.PushAsync(otherUserProfilePage);
             });
+            BackCommand = new AsyncCommand(async () =>
+            {
+                string? result = await Shell.Current.DisplayActionSheet("Are you sure you want to go back? You will lose any unsaved questions.", "Cancel", "Yes, I'm sure.");
+                if (result == "Yes, I'm sure.")
+                {
+                    _ = await Shell.Current.Navigation.PopAsync();
+                }
+            });
         }
 
         public Command<string> RaisedOptionSelectedCommand { get; }
@@ -228,6 +236,7 @@ namespace RightToAskClient.ViewModels
         public IAsyncCommand AnsweredByMyMPCommand { get; }
         public IAsyncCommand AnsweredByOtherMPCommand { get; }
         public IAsyncCommand QuestionSuggesterCommand { get; }
+        public IAsyncCommand BackCommand { get; }
         public Command SaveQuestionCommand { get; }
         public Command SelectCommitteeButtonCommand { get; }
         public Command UpvoteCommand { get; }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/AboutPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/AboutPage.xaml
@@ -2,7 +2,8 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="RightToAskClient.Views.AboutPage"
-             Title="About">
+             Title="About"
+             Shell.FlyoutBehavior="Flyout">
     <ContentPage.Content>
         <StackLayout>
             <Label Text="This page will give information about how to use the application." Style="{StaticResource Header2}"/>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/AboutPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/AboutPage.xaml.cs
@@ -16,5 +16,15 @@ namespace RightToAskClient.Views
         {
             InitializeComponent();
         }
+
+        protected override bool OnBackButtonPressedAsync()
+        {
+            Task<string>? result = Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
+            if (result.ToString() == "Yes")
+            {
+                return false; // close the application
+            }
+            return true; // otherwise do nothing
+        }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/AboutPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/AboutPage.xaml.cs
@@ -19,12 +19,7 @@ namespace RightToAskClient.Views
 
         protected override bool OnBackButtonPressed()
         {
-            //Task<string>? result = Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
-            //if (result.ToString() == "Yes")
-            //{
-            //    return false; // close the application
-            //}
-            return true; // otherwise do nothing
+            return true; // do nothing
         }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/AboutPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/AboutPage.xaml.cs
@@ -17,13 +17,13 @@ namespace RightToAskClient.Views
             InitializeComponent();
         }
 
-        protected override bool OnBackButtonPressedAsync()
+        protected override bool OnBackButtonPressed()
         {
-            Task<string>? result = Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
-            if (result.ToString() == "Yes")
-            {
-                return false; // close the application
-            }
+            //Task<string>? result = Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
+            //if (result.ToString() == "Yes")
+            //{
+            //    return false; // close the application
+            //}
             return true; // otherwise do nothing
         }
     }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/AccountPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/AccountPage.xaml
@@ -2,7 +2,8 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="RightToAskClient.Views.AccountPage"
-             Title="Account">
+             Title="Account"
+             Shell.FlyoutBehavior="Flyout">
     <ContentPage.Content>
         <StackLayout>
             <Label Text="This page will give information about the user's account details and allow them to edit." Style="{StaticResource Header2}" />

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/AccountPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/AccountPage.xaml.cs
@@ -16,5 +16,17 @@ namespace RightToAskClient.Views
         {
             InitializeComponent();
         }
+
+        protected override bool OnBackButtonPressedAsync()
+        {
+            //App.Current.MainPage.Navigation.PopToRootAsync();
+            //_ = Shell.Current.GoToAsync(nameof(MainPage));
+            Task<string>? result = Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
+            if (result.ToString() == "Yes")
+            {
+                return false; // close the application
+            }
+            return true; // otherwise do nothing
+        }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/AccountPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/AccountPage.xaml.cs
@@ -19,14 +19,7 @@ namespace RightToAskClient.Views
 
         protected override bool OnBackButtonPressed()
         {
-            //App.Current.MainPage.Navigation.PopToRootAsync();
-            //_ = Shell.Current.GoToAsync(nameof(MainPage));
-            Task<string>? result = Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
-            if (result.ToString() == "Yes")
-            {
-                return false; // close the application
-            }
-            return true; // otherwise do nothing
+            return true;
         }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/AccountPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/AccountPage.xaml.cs
@@ -17,7 +17,7 @@ namespace RightToAskClient.Views
             InitializeComponent();
         }
 
-        protected override bool OnBackButtonPressedAsync()
+        protected override bool OnBackButtonPressed()
         {
             //App.Current.MainPage.Navigation.PopToRootAsync();
             //_ = Shell.Current.GoToAsync(nameof(MainPage));

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/MainPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/MainPage.xaml
@@ -4,7 +4,8 @@
              xmlns:resx="clr-namespace:RightToAskClient.Resx"
              xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
 			 x:Class="RightToAskClient.Views.MainPage"
-			 Title="{xct:Translate ApplicationTitle}">
+			 Title="{xct:Translate ApplicationTitle}"
+             Shell.FlyoutBehavior="Flyout">
 	<ContentPage.Content>
         <StackLayout VerticalOptions="CenterAndExpand" Spacing="40">
             <Frame Style="{StaticResource NavajoWhiteFrame}">

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/MainPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/MainPage.xaml.cs
@@ -61,16 +61,5 @@ namespace RightToAskClient.Views
             //await Navigation.PushAsync(secondPage);
             await Shell.Current.GoToAsync($"{nameof(SecondPage)}");
         }
-
-        protected override bool OnBackButtonPressed()
-        {
-            return true;
-            //string? result = await Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
-            //if (result == "Yes")
-            //{
-            //    return false; // close the application
-            //}
-            //return true; // otherwise do nothing
-        }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/MainPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using RightToAskClient.Models;
 using Xamarin.Forms;
 
@@ -61,5 +62,14 @@ namespace RightToAskClient.Views
             await Shell.Current.GoToAsync($"{nameof(SecondPage)}");
         }
 
+        protected override async Task<bool> OnBackButtonPressedAsync()
+        {
+            string? result = await Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
+            if (result == "Yes")
+            {
+                return false; // close the application
+            }
+            return true; // otherwise do nothing
+        }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/MainPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/MainPage.xaml.cs
@@ -62,14 +62,15 @@ namespace RightToAskClient.Views
             await Shell.Current.GoToAsync($"{nameof(SecondPage)}");
         }
 
-        protected override async Task<bool> OnBackButtonPressedAsync()
+        protected override bool OnBackButtonPressed()
         {
-            string? result = await Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
-            if (result == "Yes")
-            {
-                return false; // close the application
-            }
-            return true; // otherwise do nothing
+            return true;
+            //string? result = await Shell.Current.DisplayActionSheet("Are you sure you want to exit?", "Cancel", "Yes");
+            //if (result == "Yes")
+            //{
+            //    return false; // close the application
+            //}
+            //return true; // otherwise do nothing
         }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
@@ -27,5 +27,12 @@ namespace RightToAskClient.Views
         {
             // Do nothing.
         }
+
+        protected override bool OnBackButtonPressedAsync()
+        {
+            App.Current.MainPage.Navigation.PopToRootAsync();
+            //_ = Shell.Current.GoToAsync(nameof(MainPage));
+            return true;
+        }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
@@ -28,7 +28,7 @@ namespace RightToAskClient.Views
             // Do nothing.
         }
 
-        protected override bool OnBackButtonPressedAsync()
+        protected override bool OnBackButtonPressed()
         {
             App.Current.MainPage.Navigation.PopToRootAsync();
             //_ = Shell.Current.GoToAsync(nameof(MainPage));

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/SecondPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/SecondPage.xaml
@@ -5,7 +5,11 @@
              xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
 			 x:Class="RightToAskClient.Views.SecondPage"
              x:DataType="vm:QuestionViewModel">
-	<ContentPage.Content>
+    <Shell.BackButtonBehavior>
+        <BackButtonBehavior Command="{Binding BackCommand}"
+                            IconOverride="back.png" />
+    </Shell.BackButtonBehavior>
+    <ContentPage.Content>
 		<StackLayout Orientation="Vertical" HorizontalOptions="Center" VerticalOptions="CenterAndExpand"
 		             Padding="30">
 			<StackLayout Orientation="Vertical" x:Name="QuestionDraftingBox" IsVisible="{Binding IsReadingOnly, Converter={StaticResource Key=cnvInvert}}">

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/SecondPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/SecondPage.xaml.cs
@@ -36,6 +36,28 @@ namespace RightToAskClient.Views
             App.ReadingContext.DraftQuestion = ((Editor)sender).Text;
             QuestionViewModel.Instance.Question.QuestionText = ((Editor)sender).Text;
         }
+
+        protected override bool OnBackButtonPressed()
+        {
+            bool result = true;
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                result = DisplayPromptBeforeNavigating();
+            });
+            return result;
+        }
+
+        protected bool DisplayPromptBeforeNavigating()
+        {
+            Device.BeginInvokeOnMainThread(async () =>
+            {
+                string? result = await Shell.Current.DisplayActionSheet("Are you sure you want to go back? You will lose any unsaved questions.", "Cancel", "Yes, I'm sure.");
+                if (result == "Yes, I'm sure.")
+                {
+                    _ = await Shell.Current.Navigation.PopAsync(); // pop
+                }
+            });
+            return true; // otherwise do nothing
+        }
     }
 }
-


### PR DESCRIPTION
Override the android native back button to not close the app from the Account and About page. Displays a prompt when returning from the second page to main and losing question data on both Nav bar back button press and android native back button.