### PR TITLE
Added a Home button to the NavBar

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Person.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Person.cs
@@ -44,7 +44,7 @@ namespace RightToAskClient.Models
         {
 	        get
 	        {
-				return findElectorateGivenPredicate(c => ParliamentData.IsUpperHouseChamber(c.chamber));
+				return RegistrationInfo.findElectorateGivenPredicate(c => ParliamentData.IsUpperHouseChamber(c.chamber));
 	        }
         }
 		
@@ -53,7 +53,7 @@ namespace RightToAskClient.Models
         {
 	        get
 	        {
-		        return findElectorateGivenPredicate(chamberPair => chamberPair.chamber == ParliamentData.Chamber.Australian_House_Of_Representatives);
+		        return RegistrationInfo.findElectorateGivenPredicate(chamberPair => chamberPair.chamber == ParliamentData.Chamber.Australian_House_Of_Representatives);
 	        }
 	        
 	        /*
@@ -72,7 +72,7 @@ namespace RightToAskClient.Models
         {
 	        get
 	        {
-		        return findElectorateGivenPredicate(chamberPair => ParliamentData.IsLowerHouseChamber(chamberPair.chamber)); 
+		        return RegistrationInfo.findElectorateGivenPredicate(chamberPair => ParliamentData.IsLowerHouseChamber(chamberPair.chamber)); 
 	        }
 	        /*
 	        var electoratePair = registrationInfo.electorates.Find(chamberPair =>
@@ -84,18 +84,6 @@ namespace RightToAskClient.Models
 
 	        return electoratePair.region;
 	        */
-        }
-
-
-        private string findElectorateGivenPredicate(Predicate<ElectorateWithChamber> func)
-        {
-	        var electoratePair = _registrationInfo.electorates.Find(func);
-	        if (electoratePair is null)
-	        {
-		        return "";
-	        }
-
-	        return electoratePair.region;
         }
 
         /*

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
@@ -9,57 +10,83 @@ using Xamarin.CommunityToolkit.ObjectModel;
 
 namespace RightToAskClient.Models
 {
-	public class Registration : ObservableObject
-	{
-		// private string stateEnum = "";
-		public string display_name { get; set; } = "";
-		public string public_key { get; set; }= "";
-		private string state { get; set; }= "";
+    public class Registration : ObservableObject
+    {
+        // private string stateEnum = "";
+        public string display_name { get; set; } = "";
+        public string public_key { get; set; } = "";
+        private string state { get; set; } = "";
 
-		public string State
-		{
-			get => state;
-			set => state = value;
-		} 
-		
-		public string uid { get; set; }= "";
+        public string State
+        {
+            get => state;
+            set => state = value;
+        }
 
-		public List<ElectorateWithChamber> electorates { get; private set; } = new List<ElectorateWithChamber>();
+        public string uid { get; set; } = "";
 
-		/* Accept a new electorate and chamber, remove any earlier ones that are inconsistent.
+        private List<ElectorateWithChamber> _electorates = new List<ElectorateWithChamber>();
+        public ObservableCollection<ElectorateWithChamber> electorates 
+        {
+            get { return new ObservableCollection<ElectorateWithChamber>(_electorates); }
+            set 
+            {
+                SetProperty(ref _electorates, value.ToList());
+            } 
+        }
+
+        /* Accept a new electorate and chamber, remove any earlier ones that are inconsistent.
 		 * Note: this assumes that nobody is ever represented in two different regions in the one
 		 * chamber. This is true throughout Aus, but may be untrue elsewhere. Of course, each region
 		 * may have multiple representatives.
 		 * Inserting it at the beginning rather than adding at the end is a bit of a hack to
 		 * put the Senators last (they're computed first).
 		 */
-		public void AddElectorateRemoveDuplicates(ElectorateWithChamber newElectorate)
-		{
-				electorates.RemoveAll(e => e.chamber == newElectorate.chamber);
-				electorates.Insert(0,newElectorate);
-		}
+        public void AddElectorateRemoveDuplicates(ElectorateWithChamber newElectorate)
+        {
+            // potentially remove any duplicates
+            _electorates.RemoveAll(e => e.chamber == newElectorate.chamber);
+            _electorates.Insert(0, newElectorate);
+            OnPropertyChanged("electorates");
+        }
 
-		public Result<bool> IsValid()
-		{
-			List<string> errorFields = new List<string>();
-			
-			foreach(PropertyInfo prop in typeof(Registration).GetProperties())
-			{
-				var value = prop.GetValue(this, null);
-				if (value is null || String.IsNullOrWhiteSpace(value.ToString()))
-				{
-					errorFields.Add(prop.Name);
-				}
-			}
+        private void Electorates_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            throw new NotImplementedException();
+        }
 
-			if (errorFields.IsNullOrEmpty() || errorFields.SequenceEqual(new List<string>{"electorates"}))
-			{
-				return new Result<bool>() { Ok = true };
-			}
-			return new Result<bool>()
-			{
-				Err ="Please complete "+String.Join(" and ",errorFields)
-			};
-		}
-	}
+        public string findElectorateGivenPredicate(Predicate<ElectorateWithChamber> func)
+        {
+            var electoratePair = _electorates.Find(func);
+            if (electoratePair is null)
+            {
+                return "";
+            }
+
+            return electoratePair.region;
+        }
+
+        public Result<bool> IsValid()
+        {
+            List<string> errorFields = new List<string>();
+
+            foreach (PropertyInfo prop in typeof(Registration).GetProperties())
+            {
+                var value = prop.GetValue(this, null);
+                if (value is null || String.IsNullOrWhiteSpace(value.ToString()))
+                {
+                    errorFields.Add(prop.Name);
+                }
+            }
+
+            if (errorFields.IsNullOrEmpty() || errorFields.SequenceEqual(new List<string> { "electorates" }))
+            {
+                return new Result<bool>() { Ok = true };
+            }
+            return new Result<bool>()
+            {
+                Err = "Please complete " + String.Join(" and ", errorFields)
+            };
+        }
+    }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
@@ -313,6 +313,15 @@ namespace RightToAskClient.Resx {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Home.
+        /// </summary>
+        internal static string HomeButtonText {
+            get {
+                return ResourceManager.GetString("HomeButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Keep Question: Review for Upload.
         /// </summary>
         internal static string KeepQuestionButtonText {

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
@@ -201,6 +201,9 @@
   <data name="FollowButtonText" xml:space="preserve">
     <value>Follow {0}</value>
   </data>
+  <data name="HomeButtonText" xml:space="preserve">
+    <value>Home</value>
+  </data>
   <data name="KeepQuestionButtonText" xml:space="preserve">
     <value>Keep Question: Review for Upload</value>
   </data>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/BaseViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/BaseViewModel.cs
@@ -7,6 +7,19 @@ namespace RightToAskClient.ViewModels
     {
         public ContentPage Page { get; set; } = new ContentPage();
 
+        // constructor
+        public BaseViewModel()
+        {
+            HomeButtonCommand = new AsyncCommand(async () =>
+            {
+                string? result = await Shell.Current.DisplayActionSheet("Are you sure you want to go home? You will lose any unsaved questions.", "Cancel", "Yes, I'm sure.");
+                if (result == "Yes, I'm sure.")
+                {
+                    await App.Current.MainPage.Navigation.PopToRootAsync();
+                }
+            });
+        }
+
         private bool _isBusy = false;
         public bool IsBusy
         {
@@ -27,5 +40,8 @@ namespace RightToAskClient.ViewModels
             get => _reportLabelText;
             set => SetProperty(ref _reportLabelText, value);
         }
+
+        // commands
+        public IAsyncCommand HomeButtonCommand { get; }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/ExploringPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/ExploringPage.xaml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="RightToAskClient.Views.ExploringPage" Title="Select the ones you want">
+             xmlns:vm="clr-namespace:RightToAskClient.ViewModels"
+             xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+             x:Class="RightToAskClient.Views.ExploringPage" 
+             Title="Select the ones you want">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem x:Name="HomeButton" Text="{xct:Translate HomeButtonText}"/>
+    </ContentPage.ToolbarItems>
     <ContentPage.Content>
 		<StackLayout x:Name="MainLayout" x:FieldModifier="protected" HorizontalOptions="Center" VerticalOptions="Start">
 			<Label x:Name="IntroText" />

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/ExploringPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/ExploringPage.xaml.cs
@@ -47,14 +47,15 @@ namespace RightToAskClient.Views
 			AllEntities = new ObservableCollection<Entity>(allEntities);
 			SelectableEntities = wrapInTags(AllEntities, selectedEntities);
 			DoneButton.Clicked += DoneMPsButton_OnClicked;
+            HomeButton.Clicked += HomeButton_Clicked;
 			
 			SetUpSelectableEntitiesAndIntroText(message);
 		}
-		 
-		/* This constructor is only used for Authorities, and hence assumed that the list to be selected from
+
+        /* This constructor is only used for Authorities, and hence assumed that the list to be selected from
 		 * consists of the complete list of authorities.
 		 */
-		public ExploringPage(ObservableCollection<Authority> selectedEntities, string message) 
+        public ExploringPage(ObservableCollection<Authority> selectedEntities, string message) 
 		{
 			InitializeComponent();
 
@@ -62,6 +63,7 @@ namespace RightToAskClient.Views
 			AllEntities = new ObservableCollection<Entity>(ParliamentData.AllAuthorities);
 			SelectableEntities = wrapInTags(AllEntities, selectedEntities);
 			DoneButton.Clicked += DoneAuthoritiesButton_OnClicked;
+			HomeButton.Clicked += HomeButton_Clicked;
 
 			SetUpSelectableEntitiesAndIntroText(message);	
 		}
@@ -73,7 +75,8 @@ namespace RightToAskClient.Views
 			IntroText.Text = message;
 			this.SelectedMPs = selectedMPs;
 			DoneButton.Clicked += DoneMPsButton_OnClicked;
-			
+			HomeButton.Clicked += HomeButton_Clicked;
+
 			AuthorityListView.IsGroupingEnabled = true;
 
 			List<TaggedGroupedEntities> groupedMPsWithTags = new List<TaggedGroupedEntities>();
@@ -93,6 +96,14 @@ namespace RightToAskClient.Views
 			SelectableEntities	= new ObservableCollection<Tag<Entity>>(groupedMPsWithTags.SelectMany(x => x).ToList());
 		}
 
+		private async void HomeButton_Clicked(object sender, EventArgs e)
+		{
+			string? result = await Shell.Current.DisplayActionSheet("Are you sure you want to go home? You will lose any unsaved questions.", "Cancel", "Yes, I'm sure.");
+			if (result == "Yes, I'm sure.")
+			{
+				await App.Current.MainPage.Navigation.PopToRootAsync();
+			}
+		}
 		private void SetUpSelectableEntitiesAndIntroText(string message)
 		{
 			IntroText.Text = message;

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionAskerPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionAskerPage.xaml
@@ -9,6 +9,9 @@
              x:Class="RightToAskClient.Views.QuestionAskerPage"
              Title="{xct:Translate Step2Title}"
              x:DataType="vm:QuestionViewModel">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="{xct:Translate HomeButtonText}" Command="{Binding HomeButtonCommand}" x:DataType="vm:BaseViewModel"/>
+    </ContentPage.ToolbarItems>
     <ContentPage.Content>
         <StackLayout x:Name = "WholePage">
 			<StackLayout x:Name="questionAsker" Style="{StaticResource VertStack}">

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml
@@ -10,6 +10,9 @@
              x:Class="RightToAskClient.Views.QuestionDetailPage"
              x:DataType="vm:QuestionViewModel"
              Title="{xct:Translate QuestionDetailsTitle}">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="{xct:Translate HomeButtonText}" Command="{Binding HomeButtonCommand}" x:DataType="vm:BaseViewModel"/>
+    </ContentPage.ToolbarItems>
     <ContentPage.Content>
 		<StackLayout x:Name="WholePage" Margin="20">
             <Label Text="{xct:Translate QuestionHeaderText}" Style="{StaticResource LeftSmall}"/>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReadingPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReadingPage.xaml
@@ -8,7 +8,10 @@
 			 x:Class="RightToAskClient.Views.ReadingPage"
 			 x:Name="TitleBar"
              Title="{xct:Translate RecentQuestionsTitle}">
-	<ContentPage.Content>
+    <ContentPage.ToolbarItems>
+        <ToolbarItem x:Name="HomeButton" Text="{xct:Translate HomeButtonText}"/>
+    </ContentPage.ToolbarItems>
+    <ContentPage.Content>
 		<StackLayout x:Name = "WholePage" HorizontalOptions="Center" VerticalOptions="Start">
             <Label Text="{xct:Translate ReadingPageHeader1}" Style="{StaticResource Header2}"></Label>
 			<!-- Filters inserted here -->

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReadingPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReadingPage.xaml.cs
@@ -18,6 +18,7 @@ namespace RightToAskClient.Views
         {
             InitializeComponent();
             BindingContext = App.ReadingContext;
+            HomeButton.Clicked += HomeButton_Clicked;
 
             _ttestableView = new FilterDisplayTableView();
             WholePage.Children.Insert(1, _ttestableView);
@@ -68,6 +69,15 @@ namespace RightToAskClient.Views
 				TitleBar.Title = "Similar questions";
 			}
 		}*/
+
+        private async void HomeButton_Clicked(object sender, EventArgs e)
+        {
+            string? result = await Shell.Current.DisplayActionSheet("Are you sure you want to go home? You will lose any unsaved questions.", "Cancel", "Yes, I'm sure.");
+            if (result == "Yes, I'm sure.")
+            {
+                await App.Current.MainPage.Navigation.PopToRootAsync();
+            }
+        }
 
         private void OnShowFilters(object sender, EventArgs e)
         {

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/RegisterPage1.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/RegisterPage1.xaml
@@ -9,6 +9,9 @@
              x:Class="RightToAskClient.Views.RegisterPage1"
              x:DataType="vm:Registration1ViewModel"
              Title="{Binding Title}">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="{xct:Translate HomeButtonText}" Command="{Binding HomeButtonCommand}" x:DataType="vm:BaseViewModel"/>
+    </ContentPage.ToolbarItems>
     <ContentPage.BindingContext>
         <vm:Registration1ViewModel />
     </ContentPage.BindingContext>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/RegisterPage2.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/RegisterPage2.xaml
@@ -9,6 +9,9 @@
              x:Class="RightToAskClient.Views.RegisterPage2"
              Title="Find your MPs"
              x:DataType="vm:FindMPsViewModel">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="{xct:Translate HomeButtonText}" Command="{Binding HomeButtonCommand}" x:DataType="vm:BaseViewModel"/>
+    </ContentPage.ToolbarItems>
     <ContentPage.BindingContext>
         <vm:FindMPsViewModel/>
     </ContentPage.BindingContext>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/SecondPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/SecondPage.xaml
@@ -5,6 +5,9 @@
              xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
 			 x:Class="RightToAskClient.Views.SecondPage"
              x:DataType="vm:QuestionViewModel">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="{xct:Translate HomeButtonText}" Command="{Binding HomeButtonCommand}" x:DataType="vm:BaseViewModel"/>
+    </ContentPage.ToolbarItems>
     <Shell.BackButtonBehavior>
         <BackButtonBehavior Command="{Binding BackCommand}"
                             IconOverride="back.png" />


### PR DESCRIPTION
Added a Home button to the NavBar across all pages that are not at the base FlyoutMenu level. Exploring and ReadingPages have their buttons handled in the codebehind page constructors using click events, while all other pages that are not created in the code behind at runtime get it from the baseViewModel homeButtonCommand. A prompt is displayed to the user so that they may cancel the home button navigation.