### PR TITLE
Updated EditUser methods and models for server questions

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Question.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Question.cs
@@ -1,3 +1,4 @@
+using RightToAskClient.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -13,16 +14,52 @@ namespace RightToAskClient.Models
         private int _upVotes;
         private int _downVotes;
 
-        public string QuestionText { get; set; } = "";
+        private string _questionText = "";
+        public string QuestionText
+        {
+            get => _questionText;
+            set
+            {
+                SetProperty(ref _questionText, value);
+                QuestionViewModel.Instance._serverQuestionUpdates.question_text = _questionText;
+            }
+        }
         public DateTime UploadTimestamp { get; set; }
-        public string Background { get; set; } = "";
+        private string _background = "";
+        public string Background
+        {
+            get => _background;
+            set
+            {
+                SetProperty(ref _background, value);
+                QuestionViewModel.Instance._serverQuestionUpdates.background = _background;
+            }
+        }
         public bool AnswerAccepted { get; set; }
         public string IsFollowupTo { get; set; } = "";
         public List<string> Keywords { get; set; } = new List<string>();
         public List<string> Category { get; set; } = new List<string>();
         public DateTime ExpiryDate { get; set; }
-        public string QuestionId { get; set; } = "";
-        public string Version { get; set; } = "";
+        private string _questionId = "";
+        public string QuestionId
+        {
+            get => _questionId;
+            set
+            {
+                SetProperty(ref _questionId, value);
+                QuestionViewModel.Instance._serverQuestionUpdates.question_id = _questionId;
+            }
+        }
+        private string _version = "";
+        public string Version
+        {
+            get => _version;
+            set
+            {
+                SetProperty(ref _version, value);
+                QuestionViewModel.Instance._serverQuestionUpdates.version = _version;
+            }
+        }
 
         // The person who suggested the question
         private string _questionSuggester = "";

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
@@ -22,7 +22,7 @@ namespace RightToAskClient.Models
 
         public ReadingContext()
         {
-	        InitializeDefaultQuestions();
+	        //InitializeDefaultQuestions(); // Needed to remove pre-existing questions to prevent a crash with the new server question models setup
         }
         public void OnPropertyChanged([CallerMemberName] string propertyName = "")
         {
@@ -61,46 +61,46 @@ namespace RightToAskClient.Models
 		
 		// At the moment, this simply populates the reading context with a
 		// hardcoded set of "existing" questions.
-		private void InitializeDefaultQuestions()
-		{
-			ExistingQuestions.Add(
-				new Question
-				{
-					QuestionText = "What is the error rate of the Senate Scanning solution?",
-					QuestionSuggester = "Alice",
-					QuestionAsker = "",
-					DownVotes = 1,
-					UpVotes = 2
-				});
-			ExistingQuestions.Add(
-				new Question
-				{
-					QuestionText = "What is the monthly payment to AWS for COVIDSafe?",
-					QuestionSuggester = "Bob",
-					QuestionAsker = "",
-					DownVotes = 3,
-					UpVotes = 1
-				});
-			ExistingQuestions.Add(
-				new Question
-				{
-					QuestionText =
-						"Why did the ABC decide against an opt-in consent model for data sharing with Facebook and Google?",
-					QuestionSuggester = "Chloe",
-					QuestionAsker = "",
-					DownVotes = 1,
-					UpVotes = 2
-				});
-			ExistingQuestions.Add(
-				new Question
-				{
-					QuestionText =
-						"What is the government's position on the right of school children to strike for climate?",
-					QuestionSuggester = "Darius",
-					DownVotes = 1,
-					UpVotes = 2
-				});
-	}
+	//	private void InitializeDefaultQuestions()
+	//	{
+	//		ExistingQuestions.Add(
+	//			new Question
+	//			{
+	//				QuestionText = "What is the error rate of the Senate Scanning solution?",
+	//				QuestionSuggester = "Alice",
+	//				QuestionAsker = "",
+	//				DownVotes = 1,
+	//				UpVotes = 2
+	//			});
+	//		ExistingQuestions.Add(
+	//			new Question
+	//			{
+	//				QuestionText = "What is the monthly payment to AWS for COVIDSafe?",
+	//				QuestionSuggester = "Bob",
+	//				QuestionAsker = "",
+	//				DownVotes = 3,
+	//				UpVotes = 1
+	//			});
+	//		ExistingQuestions.Add(
+	//			new Question
+	//			{
+	//				QuestionText =
+	//					"Why did the ABC decide against an opt-in consent model for data sharing with Facebook and Google?",
+	//				QuestionSuggester = "Chloe",
+	//				QuestionAsker = "",
+	//				DownVotes = 1,
+	//				UpVotes = 2
+	//			});
+	//		ExistingQuestions.Add(
+	//			new Question
+	//			{
+	//				QuestionText =
+	//					"What is the government's position on the right of school children to strike for climate?",
+	//				QuestionSuggester = "Darius",
+	//				DownVotes = 1,
+	//				UpVotes = 2
+	//			});
+	//}
 
 
 		// TODO This ToString doesn't really properly convey the state of

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/ServerCommsData/NewQuestionServerReceive.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/ServerCommsData/NewQuestionServerReceive.cs
@@ -8,20 +8,22 @@ namespace RightToAskClient.Models.ServerCommsData
     public class NewQuestionServerReceive
     {
         [JsonPropertyName("author")]
-        public string author { get; set; }
+        public string? author { get; set; }
         [JsonPropertyName("question_text")]
-        public string question_text { get; set; }
+        public string? question_text { get; set; }
+        [JsonPropertyName("background")]
+        public string? background { get; set; }
         [JsonPropertyName("timestamp")]
-        public int timestamp { get; set; }
+        public int? timestamp { get; set; }
         [JsonPropertyName("who_should_ask_the_question_permissions")]
-        public string who_should_ask_the_question_permissions { get; set; }
+        public string? who_should_ask_the_question_permissions { get; set; }
         [JsonPropertyName("who_should_answer_the_question_permissions")]
-        public string who_should_answer_the_question_permissions { get; set; }
+        public string? who_should_answer_the_question_permissions { get; set; }
         [JsonPropertyName("question_id")]
-        public string question_id { get; set; }
+        public string? question_id { get; set; }
         [JsonPropertyName("version")]
-        public string version { get; set; }
+        public string? version { get; set; }
         [JsonPropertyName("last_modified")]
-        public int last_modified { get; set; }
+        public int? last_modified { get; set; }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/ServerCommsData/NewQuestionServerSend.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/ServerCommsData/NewQuestionServerSend.cs
@@ -7,7 +7,7 @@ namespace RightToAskClient.Models.ServerCommsData
     public class NewQuestionServerSend
     {
         [JsonPropertyName("question_text")]
-        public string question_text { get; set; }
+        public string? question_text { get; set; }
         //[JsonPropertyName("question_writer")]
         //public string question_writer { get; set; }
         //[JsonPropertyName("upload_timestamp")]
@@ -15,7 +15,7 @@ namespace RightToAskClient.Models.ServerCommsData
 
         // non-defining fields
         [JsonPropertyName("background")]
-        public string background { get; set; }
+        public string? background { get; set; }
         //[JsonPropertyName("mp_who_should_ask_the_questions")]
         //public List<Entity> mp_who_should_ask_the_questions { get; set; }
         //[JsonPropertyName("entity_who_should_answer_the_quetions")]
@@ -27,7 +27,7 @@ namespace RightToAskClient.Models.ServerCommsData
         //[JsonPropertyName("hansard_link")]
         //public List<string> hansard_link { get; set; } // list<url>
         [JsonPropertyName("is_followup_to")]
-        public string is_followup_to { get; set; } // questionID
+        public string? is_followup_to { get; set; } // questionID
         //[JsonPropertyName("keywords")]
         //public List<string> keywords { get; set; }
         //[JsonPropertyName("category")]
@@ -36,10 +36,12 @@ namespace RightToAskClient.Models.ServerCommsData
         //public DateTime expiry_date { get; set; }
 
         // bookkeeping fields
+        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         [JsonPropertyName("question_id")]
-        public string question_id { get; set; }
+        public string? question_id { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         [JsonPropertyName("version")]
-        public string version { get; set; }
+        public string? version { get; set; }
 
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
@@ -166,7 +166,7 @@ namespace RightToAskClient.ViewModels
             {
                 QuestionText = App.ReadingContext.DraftQuestion,
                 // TODO: Enforce registration before question-suggesting.
-                QuestionSuggester = (thisParticipant.IsRegistered) ? thisParticipant.RegistrationInfo.display_name : "Anonymous user",
+                QuestionSuggester = (thisParticipant.IsRegistered) ? thisParticipant.RegistrationInfo.uid : "Anonymous user",
                 QuestionAnswerers = questionAnswerers,
                 DownVotes = 0,
                 UpVotes = 0
@@ -247,11 +247,11 @@ namespace RightToAskClient.ViewModels
                 {
                     Question temp = new Question()
                     {
-                        QuestionId = serverQuestion.question_id,
-                        QuestionText = serverQuestion.question_text,
-                        QuestionSuggester = serverQuestion.author,
-                        Version = serverQuestion.version,
-                        //Background = serverQuestion.background, // doesn't exist on the server response object yet
+                        QuestionId = serverQuestion.question_id ?? "",
+                        QuestionText = serverQuestion.question_text ?? "",
+                        QuestionSuggester = serverQuestion.author ?? "",
+                        Version = serverQuestion.version ?? "",
+                        Background = serverQuestion.background ?? "",
                         //UploadTimestamp = serverQuestion.timestamp,
                         //ExpiryDate = serverQuestion.last_modified,
                         //QuestionAsker = serverQuestion.who_should_ask_the_question_permissions,

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/Registration1ViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/Registration1ViewModel.cs
@@ -236,9 +236,9 @@ namespace RightToAskClient.ViewModels
             RegisterMPButtonText = AppResources.RegisterMPAccountButtonText;
             RegisterOrgButtonText = AppResources.RegisterOrganisationAccountButtonText;
             CanEditUID = !App.ReadingContext.ThisParticipant.IsRegistered;
-            
-             // uid should still be sent in the 'update' even though it doesn't change.
-             _registrationUpdates.uid = _registration.uid ;
+
+            // uid should still be sent in the 'update' even though it doesn't change.
+            _registrationUpdates.uid = _registration.uid;
              
             // If this is this user's profile, show them IndividualParticipant data
             // (if there is any) and give them the option to edit (or make new).
@@ -303,10 +303,6 @@ namespace RightToAskClient.ViewModels
             {
                 await Shell.Current.GoToAsync($"{nameof(ReadingPage)}");
             });
-            
-            // TODO Check that this is guaranteed to happen only after all the
-            // Components are initialized, i.e. after the fields are set.
-            // ReinitRegistrationUpdates();
         }
 
         // commands

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
@@ -24,10 +24,15 @@ namespace RightToAskClient.Views
                     if (QuestionViewModel.Instance.Question.QuestionSuggester == App.ReadingContext.ThisParticipant.RegistrationInfo.uid)
                     {
                         QuestionViewModel.Instance.CanEditBackground = true;
-                        QuestionViewModel.Instance.CanEditQuestion = true;
+                        if (!QuestionViewModel.Instance.IsNewQuestion)
+                        {
+                            QuestionViewModel.Instance.CanEditQuestion = true;
+                        }
                     }
                 }
             }
+            var vm = BindingContext as QuestionViewModel;
+            vm.ReinitQuestionUpdates();
         }
 
         // I'm not actually sure what triggers the 'send' event here, and hence not sure


### PR DESCRIPTION
Edit user now only sends the fields that have changed to the server, along with a mandatory questionId and Version string. Based on the changes for editing serverUsers.