### PR TITLE
Clickable labels for popups

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient.Android/Resources/values/styles.xml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient.Android/Resources/values/styles.xml
@@ -6,6 +6,7 @@
 	<style name="noPaddingButtonStyle" parent="android:Widget.Material.Button">
 		<item name="android:paddingLeft">0dp</item>
 		<item name="android:paddingRight">0dp</item>
+		<item name="android:textAllCaps">false</item>
 	</style>
 	<style name="MainTheme" parent="MainTheme.Base">
 		<!-- As of Xamarin.Forms 4.6 the theme has moved into the Forms binary -->

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Question.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Question.cs
@@ -11,6 +11,7 @@ using RightToAskClient.Resx;
 using Xamarin.CommunityToolkit.ObjectModel;
 using Xamarin.Essentials;
 using Xamarin.Forms;
+using Xamarin.CommunityToolkit.Extensions;
 
 namespace RightToAskClient.Models
 {
@@ -226,6 +227,19 @@ namespace RightToAskClient.Models
             set => SetProperty(ref _answerInApp, value);
         }
 
+        // booleans stored for new style popups
+        private bool _approveClicked = false;
+        public bool ApproveClicked
+        {
+            get => _approveClicked;
+            set => SetProperty(ref _approveClicked, value);
+        }
+        private bool _cancelClicked = false;
+        public bool CancelClicked
+        {
+            get => _cancelClicked;
+            set => SetProperty(ref _cancelClicked, value);
+        }
         /*
         public override string ToString ()
         {
@@ -269,13 +283,17 @@ namespace RightToAskClient.Models
                 else
                 {
                     string message = AppResources.CreateAccountPopUpText;
-                    //var popup = new TwoButtonPopup();// this instance uses a model instead of a VM
-                    //_ = await App.Current.MainPage.Navigation.ShowPopupAsync(popup);
-                    bool registerNow = await App.Current.MainPage.DisplayAlert(AppResources.MakeAccountQuestionText, message, AppResources.OKText, AppResources.NotNowAnswerText);
-                    if (registerNow)
+                    var popup = new TwoButtonPopup(this, AppResources.MakeAccountQuestionText, message, AppResources.NotNowAnswerText, AppResources.OKText); // this instance uses a model instead of a VM
+                    _ = await App.Current.MainPage.Navigation.ShowPopupAsync(popup);
+                    if (ApproveClicked)
                     {
                         await Shell.Current.GoToAsync($"{nameof(RegisterPage1)}");
                     }
+                    //bool registerNow = await App.Current.MainPage.DisplayAlert(AppResources.MakeAccountQuestionText, message, AppResources.OKText, AppResources.NotNowAnswerText);
+                    //if (registerNow)
+                    //{
+                    //    await Shell.Current.GoToAsync($"{nameof(RegisterPage1)}");
+                    //}
                 }
             });
             QuestionDetailsCommand = new Command(() =>
@@ -305,11 +323,23 @@ namespace RightToAskClient.Models
                     App.ReadingContext.ThisParticipant.ReportedQuestionIDs.Remove(QuestionId);
                 }
             });
+            PopupApproveCommand = new Command(() =>
+            {
+                ApproveClicked = true;
+                CancelClicked = false;
+            });
+            PopupCancelCommand = new Command(() =>
+            {
+                CancelClicked = true;
+                ApproveClicked = false;
+            });
         }
 
         // commands
         public Command UpvoteCommand { get; }
         public Command ReportCommand { get; }
+        public Command PopupApproveCommand { get; }
+        public Command PopupCancelCommand { get; }
         public Command QuestionDetailsCommand { get; }
         public IAsyncCommand ShareCommand { get; }
         

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/BaseViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/BaseViewModel.cs
@@ -29,6 +29,17 @@ namespace RightToAskClient.ViewModels
                 var popup = new InfoPopup(PopupLabelText);
                 _ = await App.Current.MainPage.Navigation.ShowPopupAsync(popup);
             });
+            ApproveCommand = new Command(() =>
+            {
+                ApproveButtonClicked = true;
+                CancelButtonClicked = false;
+                //Dismiss();
+            });
+            CancelCommand = new Command(() =>
+            {
+                ApproveButtonClicked = false;
+                CancelButtonClicked = true;
+            });
         }
 
         private bool _isBusy = false;
@@ -66,5 +77,7 @@ namespace RightToAskClient.ViewModels
         // commands
         public IAsyncCommand HomeButtonCommand { get; }
         public IAsyncCommand InfoPopupCommand { get; }
+        public Command ApproveCommand { get; set; }
+        public Command CancelCommand { get; set; }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/InfoPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/InfoPopup.xaml
@@ -14,7 +14,8 @@
                    TextColor="{AppThemeBinding Light={StaticResource TextColor}, 
                    Dark={StaticResource TextColorDark}}"/>
             <Grid ColumnDefinitions="*,*" VerticalOptions="EndAndExpand">
-                <Button x:Name="okButton" Text="{xct:Translate OKText}" Grid.Column="1" Clicked="okButton_Clicked" HeightRequest="50" Style="{StaticResource GreenButton}"/>
+                <Button x:Name="okButton" Text="{xct:Translate OKText}" Grid.Column="1" Clicked="okButton_Clicked" FontSize="Small" 
+                        TextColor="{StaticResource TextColorGreen}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
             </Grid>
         </StackLayout>
     </Frame>        

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/OneButtonPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/OneButtonPopup.xaml
@@ -13,7 +13,11 @@
                    HorizontalOptions="Center" HorizontalTextAlignment="Center" Style="{StaticResource Header1}"
                    TextColor="{AppThemeBinding Light={StaticResource TextColor}, 
                    Dark={StaticResource TextColorDark}}"/>
-            <Button x:Name="okButton" Clicked="okButton_Clicked" HeightRequest="75" VerticalOptions="End"/>
+            <Grid ColumnDefinitions="*,*" VerticalOptions="EndAndExpand">
+                <Button x:Name="okButton" Grid.Column="1" Clicked="okButton_Clicked" FontSize="Small" 
+                        TextColor="{StaticResource TextColorGreen}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" 
+                        Padding="0" HorizontalOptions="FillAndExpand"/>
+            </Grid>
         </StackLayout>
     </Frame>
 </xct:Popup>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionPublishedPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionPublishedPopup.xaml
@@ -13,9 +13,11 @@
                    HorizontalOptions="Center" HorizontalTextAlignment="Center" Style="{StaticResource Header1}"
                    TextColor="{AppThemeBinding Light={StaticResource TextColor}, 
                    Dark={StaticResource TextColorDark}}"/>
-            <Grid ColumnDefinitions="*,*" VerticalOptions="End">
-                <Button Grid.Column="0" Text="{xct:Translate WriteAnotherQuestionButtonText}" Clicked="WriteAnotherButtonClicked" HeightRequest="75"/>
-                <Button Grid.Column="1" Text="{xct:Translate GoHomeButtonText}" Clicked="GoHomeButtonClicked" HeightRequest="75"/>
+            <Grid ColumnDefinitions="*,*" VerticalOptions="End" BackgroundColor="Transparent">
+                <Button Text="{xct:Translate WriteAnotherQuestionButtonText}" Grid.Column="0" Clicked="WriteAnotherButtonClicked" FontSize="Small" 
+                        TextColor="{StaticResource AlertColor}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
+                <Button Text="{xct:Translate GoHomeButtonText}" Grid.Column="1" Clicked="GoHomeButtonClicked" FontSize="Small" 
+                        TextColor="{StaticResource TextColorGreen}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
             </Grid>
         </StackLayout>
     </Frame>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReadingPagePopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReadingPagePopup.xaml
@@ -12,7 +12,7 @@
     <StackLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" BackgroundColor="Transparent">
         <Frame CornerRadius="30" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" 
                BackgroundColor="{AppThemeBinding Light={StaticResource WindowBackgroundColor}, Dark={StaticResource WindowBackgroundColorDark}}">
-            <StackLayout>
+            <StackLayout VerticalOptions="FillAndExpand" BackgroundColor="Transparent">
                 <Label Text="{xct:Translate ReadingPageHeader1}" VerticalOptions="Center" VerticalTextAlignment="Center" 
                    HorizontalOptions="Center" HorizontalTextAlignment="Center" Style="{StaticResource Header1}"
                    TextColor="{AppThemeBinding Light={StaticResource TextColor}, 
@@ -21,8 +21,9 @@
                     <Label Text="Don't show this again: " VerticalOptions="Center"/>
                     <CheckBox IsChecked="{Binding DontShowFirstTimeReadingPopup}"/>
                 </StackLayout>
-                <Grid RowDefinitions="*,*" ColumnDefinitions="*,*">
-                    <Button Grid.Row="1" Grid.Column="1" Text="{xct:Translate OKText}" Clicked="Button_Clicked"/>
+                <Grid ColumnDefinitions="*,*" VerticalOptions="EndAndExpand" BackgroundColor="Transparent">
+                    <Button Text="{xct:Translate OKText}" Grid.Column="1" Clicked="Button_Clicked" FontSize="Small" 
+                        TextColor="{StaticResource TextColorGreen}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
                 </Grid>
             </StackLayout>
         </Frame>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml
@@ -9,8 +9,8 @@
            Color="Transparent">
     <Frame CornerRadius="30" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" 
                BackgroundColor="{AppThemeBinding Light={StaticResource WindowBackgroundColor}, Dark={StaticResource WindowBackgroundColorDark}}">
-        <StackLayout>
-            <ScrollView>
+        <StackLayout VerticalOptions="FillAndExpand" BackgroundColor="Transparent">
+            <ScrollView VerticalOptions="FillAndExpand">
                 <StackLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" BackgroundColor="Transparent">
                     <Label x:Name="mainTitle" VerticalOptions="StartAndExpand" VerticalTextAlignment="Center" 
                        HorizontalOptions="Center" HorizontalTextAlignment="Center" Style="{StaticResource Header1}"
@@ -22,7 +22,7 @@
                        Dark={StaticResource TextColorDark}}"/>
                 </StackLayout>
             </ScrollView>
-            <Grid ColumnDefinitions="*,*" VerticalOptions="End">
+            <Grid x:Name="vmButtons" ColumnDefinitions="*,*" VerticalOptions="End" BackgroundColor="Transparent">
                 <!--<Label x:Name="cancelText" Grid.Column="0" TextColor="{StaticResource AlertColor}" FontSize="Small" 
                        VerticalTextAlignment="Center" VerticalOptions="Center" HorizontalTextAlignment="Center" HorizontalOptions="Center">
                     <Label.GestureRecognizers>
@@ -38,6 +38,24 @@
                 <Button x:Name="cancelButton" Grid.Column="0" Clicked="CancelButtonClicked" FontSize="Small" 
                         TextColor="{StaticResource AlertColor}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
                 <Button x:Name="approveButton" Grid.Column="1" Clicked="ApproveButtonClicked" FontSize="Small" 
+                        TextColor="{StaticResource TextColorGreen}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
+            </Grid>
+            <Grid x:Name="modelButtons" ColumnDefinitions="*,*" VerticalOptions="End" BackgroundColor="Transparent">
+                <!--<Label x:Name="cancelText" Grid.Column="0" TextColor="{StaticResource AlertColor}" FontSize="Small" 
+                       VerticalTextAlignment="Center" VerticalOptions="Center" HorizontalTextAlignment="Center" HorizontalOptions="Center">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding ApproveCommand}" x:DataType="vm:BaseViewModel"/>
+                    </Label.GestureRecognizers>
+                </Label>
+                <Label x:Name="approveText" Grid.Column="1" TextColor="{StaticResource TextColorGreen}" FontSize="Small" 
+                       VerticalTextAlignment="Center" VerticalOptions="Center" HorizontalTextAlignment="Center" HorizontalOptions="Center">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding CancelCommand}" x:DataType="vm:BaseViewModel"/>
+                    </Label.GestureRecognizers>
+                </Label>-->
+                <Button x:Name="modelCancelButton" Grid.Column="0" Clicked="ModelCancelButtonClicked" FontSize="Small" 
+                        TextColor="{StaticResource AlertColor}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
+                <Button x:Name="modelApproveButton" Grid.Column="1" Clicked="ModelApproveButtonClicked" FontSize="Small" 
                         TextColor="{StaticResource TextColorGreen}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
             </Grid>
         </StackLayout>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml
@@ -2,6 +2,7 @@
 <xct:Popup xmlns="http://xamarin.com/schemas/2014/forms"
            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
            xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+           xmlns:vm="clr-namespace:RightToAskClient.ViewModels"
            x:Class="RightToAskClient.Views.TwoButtonPopup"
            Size="300,210"
            IsLightDismissEnabled="False"
@@ -22,20 +23,22 @@
                 </StackLayout>
             </ScrollView>
             <Grid ColumnDefinitions="*,*" VerticalOptions="End">
-                <Label x:Name="cancelText" Grid.Column="0" TextColor="{StaticResource AlertColor}" FontSize="Small" 
+                <!--<Label x:Name="cancelText" Grid.Column="0" TextColor="{StaticResource AlertColor}" FontSize="Small" 
                        VerticalTextAlignment="Center" VerticalOptions="Center" HorizontalTextAlignment="Center" HorizontalOptions="Center">
-                    <!--<Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding AnsweringMPsFilterCommand}"/>
-                    </Label.GestureRecognizers>-->
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding ApproveCommand}" x:DataType="vm:BaseViewModel"/>
+                    </Label.GestureRecognizers>
                 </Label>
                 <Label x:Name="approveText" Grid.Column="1" TextColor="{StaticResource TextColorGreen}" FontSize="Small" 
                        VerticalTextAlignment="Center" VerticalOptions="Center" HorizontalTextAlignment="Center" HorizontalOptions="Center">
-                    <!--<Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding AnsweringMPsFilterCommand}"/>
-                    </Label.GestureRecognizers>-->
-                </Label>
-                <!--<Button x:Name="cancelButton" Grid.Column="0" Clicked="CancelButtonClicked" HeightRequest="50" Style="{StaticResource GreenButton}"/>-->
-                <!--<Button x:Name="approveButton" Grid.Column="1" Clicked="ApproveButtonClicked" HeightRequest="50" Style="{StaticResource GreenButton}"/>-->
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding CancelCommand}" x:DataType="vm:BaseViewModel"/>
+                    </Label.GestureRecognizers>
+                </Label>-->
+                <Button x:Name="cancelButton" Grid.Column="0" Clicked="CancelButtonClicked" FontSize="Small" 
+                        TextColor="{StaticResource AlertColor}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
+                <Button x:Name="approveButton" Grid.Column="1" Clicked="ApproveButtonClicked" FontSize="Small" 
+                        TextColor="{StaticResource TextColorGreen}" HeightRequest="50" BackgroundColor="Transparent" Margin="0" Padding="0" HorizontalOptions="FillAndExpand"/>
             </Grid>
         </StackLayout>
     </Frame>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml
@@ -3,7 +3,7 @@
            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
            xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
            x:Class="RightToAskClient.Views.TwoButtonPopup"
-           Size="300,200"
+           Size="300,210"
            IsLightDismissEnabled="False"
            Color="Transparent">
     <Frame CornerRadius="30" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" 
@@ -22,8 +22,20 @@
                 </StackLayout>
             </ScrollView>
             <Grid ColumnDefinitions="*,*" VerticalOptions="End">
-                <Button x:Name="cancelButton" Grid.Column="0" Clicked="CancelButtonClicked" HeightRequest="75" Style="{StaticResource GreenButton}"/>
-                <Button x:Name="approveButton" Grid.Column="1" Clicked="ApproveButtonClicked" HeightRequest="75" Style="{StaticResource GreenButton}"/>
+                <Label x:Name="cancelText" Grid.Column="0" TextColor="{StaticResource AlertColor}" FontSize="Small" 
+                       VerticalTextAlignment="Center" VerticalOptions="Center" HorizontalTextAlignment="Center" HorizontalOptions="Center">
+                    <!--<Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding AnsweringMPsFilterCommand}"/>
+                    </Label.GestureRecognizers>-->
+                </Label>
+                <Label x:Name="approveText" Grid.Column="1" TextColor="{StaticResource TextColorGreen}" FontSize="Small" 
+                       VerticalTextAlignment="Center" VerticalOptions="Center" HorizontalTextAlignment="Center" HorizontalOptions="Center">
+                    <!--<Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding AnsweringMPsFilterCommand}"/>
+                    </Label.GestureRecognizers>-->
+                </Label>
+                <!--<Button x:Name="cancelButton" Grid.Column="0" Clicked="CancelButtonClicked" HeightRequest="50" Style="{StaticResource GreenButton}"/>-->
+                <!--<Button x:Name="approveButton" Grid.Column="1" Clicked="ApproveButtonClicked" HeightRequest="50" Style="{StaticResource GreenButton}"/>-->
             </Grid>
         </StackLayout>
     </Frame>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml.cs
@@ -1,4 +1,5 @@
-﻿using RightToAskClient.ViewModels;
+﻿using RightToAskClient.Models;
+using RightToAskClient.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,14 +15,16 @@ namespace RightToAskClient.Views
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class TwoButtonPopup : Popup
     {
-        BaseViewModel baseViewModel;
-        //ObservableObject model;
+        BaseViewModel? baseViewModel;
+        Question? model;
         // constructor for ViewModels
         public TwoButtonPopup(BaseViewModel vm, string popupTitle, string popupText, string cancelMessage, string approveMessage)
         {
             InitializeComponent();
             baseViewModel = vm;
             BindingContext = vm;
+            vmButtons.IsVisible = true;
+            modelButtons.IsVisible = false;
             mainTitle.Text = popupTitle;
             mainMessage.Text = popupText;
             cancelButton.Text = cancelMessage;
@@ -30,16 +33,19 @@ namespace RightToAskClient.Views
             //approveText.Text = approveMessage;
         }
 
-        // constructor for Models -- The incoming Model must have boolean property to store the result of the button clicks
-        //public TwoButtonPopup(ObservableObject m, string popupText, string cancelMessage, string approveMessage)
-        //{
-        //    InitializeComponent();
-        //    model = m;
-        //    BindingContext = m;
-        //    mainMessage.Text = popupText;
-        //    cancelButton.Text = cancelMessage;
-        //    approveButton.Text = approveMessage;
-        //}
+        //constructor for Models -- The incoming Question Model type must have boolean property to store the result of the button clicks
+        public TwoButtonPopup(Question q, string popupTitle, string popupText, string cancelMessage, string approveMessage)
+        {
+            InitializeComponent();
+            model = q;
+            BindingContext = q;
+            vmButtons.IsVisible = false;
+            modelButtons.IsVisible = true;
+            mainTitle.Text = popupTitle;
+            mainMessage.Text = popupText;
+            modelCancelButton.Text = cancelMessage;
+            modelApproveButton.Text = approveMessage;
+        }
 
         private void DismissPopup(object sender, EventArgs e)
         {
@@ -61,6 +67,25 @@ namespace RightToAskClient.Views
             {
                 baseViewModel.ApproveButtonClicked = true;
                 baseViewModel.CancelButtonClicked = false;
+            }
+            Dismiss("Dismissed");
+        }
+
+        private void ModelCancelButtonClicked(object sender, EventArgs e)
+        {
+            if (model != null)
+            {
+                model.ApproveClicked = false;
+                model.CancelClicked = true;
+            }
+            Dismiss("Dismissed");
+        }
+        private void ModelApproveButtonClicked(object sender, EventArgs e)
+        {
+            if (model != null)
+            {
+                model.ApproveClicked = true;
+                model.CancelClicked = false;
             }
             Dismiss("Dismissed");
         }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml.cs
@@ -24,8 +24,10 @@ namespace RightToAskClient.Views
             BindingContext = vm;
             mainTitle.Text = popupTitle;
             mainMessage.Text = popupText;
-            cancelButton.Text = cancelMessage;
-            approveButton.Text = approveMessage;
+            //cancelButton.Text = cancelMessage;
+            //approveButton.Text = approveMessage;
+            cancelText.Text = cancelMessage;
+            approveText.Text = approveMessage;
         }
 
         // constructor for Models -- The incoming Model must have boolean property to store the result of the button clicks

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/TwoButtonPopup.xaml.cs
@@ -24,10 +24,10 @@ namespace RightToAskClient.Views
             BindingContext = vm;
             mainTitle.Text = popupTitle;
             mainMessage.Text = popupText;
-            //cancelButton.Text = cancelMessage;
-            //approveButton.Text = approveMessage;
-            cancelText.Text = cancelMessage;
-            approveText.Text = approveMessage;
+            cancelButton.Text = cancelMessage;
+            approveButton.Text = approveMessage;
+            //cancelText.Text = cancelMessage;
+            //approveText.Text = approveMessage;
         }
 
         // constructor for Models -- The incoming Model must have boolean property to store the result of the button clicks


### PR DESCRIPTION
Made the style of the buttons for the popouts match up. Yes, I named the branch Clickable Labels with the hope of using labels as the main style element, but since the gestureRecognizers use Commands instead of click events, and the ViewModels that would create those Commands could not call the Dismiss() method to close the popup, I went back to using buttons (but matched their style to the label/text-only style that you had intended). Let me know if this is acceptable.

Got the buttons pushed to the end of the vertical space on the stackLayout of the popup. 
Added fields to allow for the displayAlert from the Question.cs model to use the generic TwoButtonPopup.