### PR TITLE
Data structure cleanup

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
@@ -56,8 +56,6 @@ namespace RightToAskClient
             {
 			    ReadingContext.Filters.UpdateMyMPLists();
             }
-            
-            ReadingContext.ShowHowToPublishPopup = Preferences.Get(Constants.ShowHowToPublishPopup, true);
         }
 
         protected override void OnSleep()

--- a/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
@@ -19,7 +19,9 @@ namespace RightToAskClient
 {
     public partial class App : Application
     {
-        public static ReadingContext ReadingContext = new ReadingContext();
+        // The selections of MPs, authorities, and various other options that is gradually
+        // built as we step through the question-writing process.
+        public static FilterChoices GlobalFilterChoices = new FilterChoices();
         public App()
         {
             LocalizationResourceManager.Current.PropertyChanged += (temp, temp2) => AppResources.Culture = LocalizationResourceManager.Current.CurrentCulture;
@@ -47,14 +49,13 @@ namespace RightToAskClient
             var signingKeyRetrieved = await ClientSignatureGenerationService.Init();
             
             // Order is important here: the Filters need to be (re-)initialised after we've read MP and Committee data.
-		    ReadingContext.Filters.InitSelectableLists();
+		    GlobalFilterChoices.InitSelectableLists();
             
-	        // Consider awaiting. I don't think so, though, because there's no reason everything else should wait for it.
             IndividualParticipant.Init();
             
             if(IndividualParticipant.ElectoratesKnown) 
             {
-			    ReadingContext.Filters.UpdateMyMPLists();
+			    GlobalFilterChoices.UpdateMyMPLists();
             }
         }
 

--- a/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
@@ -5,6 +5,7 @@ using RightToAskClient.Resx;
 using Xamarin.Essentials;
 using System.Text.Json;
 using System.Diagnostics;
+using RightToAskClient.CryptoUtils;
 using RightToAskClient.Models.ServerCommsData;
 using RightToAskClient.Views;
 
@@ -38,76 +39,22 @@ namespace RightToAskClient
         protected override async void OnStart()
         {
             // ResetAppData(); // Toggle this line in and out as needed instead of resetting the emulator every time
+            
+            // We do not use these values, but for reasons I don't fully understand, the return value seemed to make the
+            // async code actually execute.
             var MPInitSuccess = await ParliamentData.MPAndOtherData.TryInit();
             var CommitteeInitSuccess = await CommitteesAndHearingsData.CommitteesData.TryInitialisingFromServer();
-            var me = ReadingContext.ThisParticipant;
+            var signingKeyRetrieved = await ClientSignatureGenerationService.Init();
             
             // Order is important here: the Filters need to be (re-)initialised after we've read MP and Committee data.
 		    ReadingContext.Filters.InitSelectableLists();
             
-            // get account info from preferences
-            var registrationPref = Preferences.Get(Constants.RegistrationInfo, "");
-            if (!string.IsNullOrEmpty(registrationPref))
-            {
-                var registrationObj = JsonSerializer.Deserialize<ServerUser>(registrationPref);
-                me.RegistrationInfo 
-                    = registrationObj is null ? new Registration() : new Registration(registrationObj);
-                
-                // We actually need to check for the stored "IsRegistered" boolean, in case they tried to
-                // register but failed, for example because the server was offline.
-                // So we may have stored Registration data, but not have actually succeeded in uploading it.
-                var registrationSuccess = Preferences.Get(Constants.IsRegistered, false);
-                me.IsRegistered = registrationSuccess;
-                
-                // We have a problem if our stored registration is null but we think we registered successfully.
-                Debug.Assert(registrationObj != null || registrationSuccess is false);
-                
-                // If we got electorates, let the app know to skip the Find My MPs step
-                // TODO We may want to distinguish between ElectoratesKnown and Electorates.Any, because
-                // the latter is true if only the state is known (Senate State being an electorate).
-                // At the moment, this will set ElectoratesKnown, in both the app and the preferences, when the person
-                // has selected their state, regardless of whether we know their electorate.
-                var electoratesKnown = Preferences.Get(Constants.ElectoratesKnown, false);
-                me.ElectoratesKnown = electoratesKnown;
-                if(electoratesKnown) 
-                {
-			        ReadingContext.Filters.UpdateMyMPLists();
-                }
-                
-                // Retrieve MP/staffer registration. Note that staffers have both the IsVerifiedMPAccount flag and the
-                // IsVerifiedMPStafferAccount flag set to true.
-                var isVerifiedMPAccount = Preferences.Get(Constants.IsVerifiedMPAccount, false);
-                me.IsVerifiedMPAccount = isVerifiedMPAccount;
-                if (isVerifiedMPAccount)
-                {
-                    me.IsVerifiedMPStafferAccount =
-                        Preferences.Get(Constants.IsVerifiedMPStafferAccount, false);
-                    
-                    // Used when uploading an answer. 
-                    var MPRepresentingjson = Preferences.Get(Constants.MPRegisteredAs, "");
-                    if (!string.IsNullOrEmpty(MPRepresentingjson))
-                    {
-                        var MPRepresenting = JsonSerializer.Deserialize<MP>(MPRepresentingjson);
-                        if (MPRepresenting != null)
-                        {
-                            // See if we can find the registered MP in our existing list.
-                            // Using field-equality operator.
-                            // If so, just keep a pointer to it; if not, use a new MP object.
-                            me.MPRegisteredAs =
-                                ParliamentData.FindMPOrMakeNewOne(MPRepresenting);
-                        }
-                    }
-                }
-            }
+	        // Consider awaiting. I don't think so, though, because there's no reason everything else should wait for it.
+            IndividualParticipant.Init();
             
-            // If we already have stored a valid state, use it and set StateKnown to true.
-            me.RegistrationInfo.StateKnown = false; // Should already be the default.
-            var stateString =  Preferences.Get(Constants.State, "");
-            var state = ParliamentData.StateStringToEnum(stateString);
-            if (string.IsNullOrEmpty(state.Err) && !string.IsNullOrEmpty(stateString))
+            if(IndividualParticipant.ElectoratesKnown) 
             {
-                me.RegistrationInfo.StateKnown = true;
-                me.RegistrationInfo.SelectedStateAsEnum = state.Ok;
+			    ReadingContext.Filters.UpdateMyMPLists();
             }
             
             // set popup bool

--- a/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
@@ -57,10 +57,7 @@ namespace RightToAskClient
 			    ReadingContext.Filters.UpdateMyMPLists();
             }
             
-            // set popup bool
-            ReadingContext.DontShowFirstTimeReadingPopup = Preferences.Get(Constants.DontShowFirstTimeReadingPopup, false);
             ReadingContext.ShowHowToPublishPopup = Preferences.Get(Constants.ShowHowToPublishPopup, true);
-            //ReadingContext.ThisParticipant.HasQuestions = Preferences.Get(Constants.HasQuestions, false);
         }
 
         protected override void OnSleep()

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Constants.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Constants.cs
@@ -19,7 +19,7 @@ namespace RightToAskClient
         public static string IsRegistered = "IsRegistered";
         public static string RegistrationInfo = "RegistrationInfo";
         public static string State = "State";
-        public static string DontShowFirstTimeReadingPopup = "DontShowFirstTimeReadingPopup";
+        public static string ShowFirstTimeReadingPopup = "ShowFirstTimeReadingPopup";
         public static string ShowHowToPublishPopup = "ShowHowToPublishPopup";
         public static string HasQuestions = "HasQuestions";
         public static string ElectoratesKnown = "ElectoratesKnown";

--- a/RightToAskClient/RightToAskClient/RightToAskClient/CryptoUtils/ClientSignatureGenerationService.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/CryptoUtils/ClientSignatureGenerationService.cs
@@ -50,35 +50,13 @@ namespace RightToAskClient.CryptoUtils
             }
             
             _myKeyPair = generationResult.Ok;
-            // _myPublicKey = _myKeyPair.GeneratePublicKey();
             MySigner.Init(true, _myKeyPair);
             InitSuccessful = true;
             return true;
         }
 
-        /*
-        public static async Task<ClientSignatureGenerationService> CreateClientSignatureGenerationService()
-        {
-            Ed25519PrivateKeyParameters myKeyPair = await MakeMyKey();
-            return new ClientSignatureGenerationService(myKeyPair);
-        }
-        */
 
         public static string MyPublicKey => Convert.ToBase64String(_myKeyPair?.GeneratePublicKey().GetEncoded() ?? Array.Empty<byte>());
-        /*
-        public static string MyPublicKey()
-        {
-            if (_myPublicKey.GetEncoded() != null)
-            {
-                return Convert.ToBase64String(_myPublicKey.GetEncoded());
-            }
-            else
-            {
-                Debug.WriteLine("Error generating signing key");
-                return "";
-            }
-        }
-        */
 
         private static async Task<Result<Ed25519PrivateKeyParameters>> MakeMyKey()
         {

--- a/RightToAskClient/RightToAskClient/RightToAskClient/CryptoUtils/ClientSignatureGenerationService.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/CryptoUtils/ClientSignatureGenerationService.cs
@@ -43,13 +43,13 @@ namespace RightToAskClient.CryptoUtils
         public static async Task<bool> Init()
         {
             var generationResult = await MakeMyKey();
-            if (!string.IsNullOrEmpty(generationResult.Err))
+            if (generationResult.Failure)
             {
-                // Key generation unsuccessful.
                 return false;
             }
             
-            _myKeyPair = generationResult.Ok;
+            // generationResult.Success
+            _myKeyPair = generationResult.Data;
             MySigner.Init(true, _myKeyPair);
             InitSuccessful = true;
             return true;
@@ -58,7 +58,7 @@ namespace RightToAskClient.CryptoUtils
 
         public static string MyPublicKey => Convert.ToBase64String(_myKeyPair?.GeneratePublicKey().GetEncoded() ?? Array.Empty<byte>());
 
-        private static async Task<Result<Ed25519PrivateKeyParameters>> MakeMyKey()
+        private static async Task<JOSResult<Ed25519PrivateKeyParameters>> MakeMyKey()
         {
             // First see if there's already a stored key. If so, use that.
             try
@@ -69,10 +69,9 @@ namespace RightToAskClient.CryptoUtils
                 if (!string.IsNullOrEmpty(signingKeyAsString))
                 {
                     var privateKey = new Ed25519PrivateKeyParameters(Convert.FromBase64String(signingKeyAsString));
-                    return new Result<Ed25519PrivateKeyParameters>()
-                    {
-                        Ok = privateKey
-                    };
+                    
+                    // Successful retrieval of old key.
+                    return new SuccessResult<Ed25519PrivateKeyParameters>(privateKey);
                 }
             }
             // If there's an exception, write a debug message and continue through generating a new one.
@@ -104,25 +103,16 @@ namespace RightToAskClient.CryptoUtils
             catch (Exception ex)
             {
                 Debug.WriteLine("Error storing signing key" + ex.Message);
-                return new Result<Ed25519PrivateKeyParameters>()
-                {
-                    Err = "Error storing signing key" + ex.Message
-                };
+                return new ErrorResult<Ed25519PrivateKeyParameters>("Error storing signing key" + ex.Message);
             }
 
             if (signingKey is null)
             {
-                return new Result<Ed25519PrivateKeyParameters>()
-                {
-                    Err = "Error generating signing key"
-                };
+                return new ErrorResult<Ed25519PrivateKeyParameters>("Error generating signing key");
             }
             
-            // signingKey is guaranteed not to be null. All good.
-            return new Result<Ed25519PrivateKeyParameters>()
-            {
-                Ok = signingKey
-            };
+            // Successful generation of new key.
+            return new SuccessResult<Ed25519PrivateKeyParameters>(signingKey);
         }
 
         public static ClientSignedUnparsed SignMessage<T>(T message, string userId)

--- a/RightToAskClient/RightToAskClient/RightToAskClient/CryptoUtils/SignatureVerificationService.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/CryptoUtils/SignatureVerificationService.cs
@@ -25,15 +25,16 @@ namespace RightToAskClient.CryptoUtils
         public static bool VerifySignature(SignedString signedString, string publicKey)
         {
             var keyResult = ConvertSPKIRawToBase64String(publicKey);
-            if (!string.IsNullOrEmpty(keyResult.Err))
+            if (keyResult.Failure)
             {
                 return false;
             }
             
+            // keyResult.Success. We retrieved a key successfully - now use it to verify the signature.
             var signatureBytes = Convert.FromBase64String(signedString.signature);
-            return VerifySignature(signedString.message, signatureBytes, keyResult.Ok);
+            return VerifySignature(signedString.message, signatureBytes, keyResult.Data);
         }
-        private static Result<Ed25519PublicKeyParameters> ConvertSPKIRawToBase64String(string keyAsString)
+        private static JOSResult<Ed25519PublicKeyParameters> ConvertSPKIRawToBase64String(string keyAsString)
         {
             Ed25519PublicKeyParameters key;
             try
@@ -44,9 +45,9 @@ namespace RightToAskClient.CryptoUtils
             {
                 Debug.WriteLine("Error decoding base 64 string. Try removing \" characters from the beginning or end of your PublicServerKey or GeoscapeAPIKey file.");
                 Debug.WriteLine(ex.Message);
-                return new Result<Ed25519PublicKeyParameters>() { Err = "Error decoding base 64 string." + ex.Message };
+                return new ErrorResult<Ed25519PublicKeyParameters>("Error decoding base 64 string." + ex.Message);
             }
-            return new Result<Ed25519PublicKeyParameters>() { Ok = key }; 
+            return new SuccessResult<Ed25519PublicKeyParameters>(key); 
         } 
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/FileIO.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/FileIO.cs
@@ -79,7 +79,7 @@ namespace RightToAskClient.Helpers
 			}
 			catch (IOException e)
 			{
-				Debug.WriteLine("File could not be read: " + filename);
+				Debug.WriteLine("Error reading file: " + filename);
 				Debug.WriteLine(e.Message);
 			}
 

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/FileIO.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/FileIO.cs
@@ -91,12 +91,12 @@ namespace RightToAskClient.Helpers
 			try
 			{
 				var streamResult = TryToGetFileStream(filename);
-				if (!string.IsNullOrEmpty(streamResult.Err))
+				if (streamResult.Failure)
 				{
 					return;
 				}
 
-				using var sr = new StreamReader(streamResult.Ok);
+				using var sr = new StreamReader(streamResult.Data);
 				// Read the first line, which just has headings we can ignore.
 				sr.ReadLine();
 				while (sr.ReadLine() is { } line)

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/FileIO.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/FileIO.cs
@@ -10,77 +10,71 @@ namespace RightToAskClient.Helpers
 {
 	public static class FileIO
 	{
-		public static Result<T> ReadDataFromStoredJson<T>(string filename, JsonSerializerOptions jsonSerializerOptions)
+		public static JOSResult<T> ReadDataFromStoredJson<T>(string filename,
+			JsonSerializerOptions jsonSerializerOptions)
 		{
 			T deserializedData;
 
 			try
 			{
 				var streamResult = TryToGetFileStream(filename);
-				if (!string.IsNullOrEmpty(streamResult.Err))
+				if (streamResult.Success)
 				{
-					return new Result<T>() { Err = streamResult.Err };
+					using var sr = new StreamReader(streamResult.Data);
+					var dataString = sr.ReadToEnd();
+					deserializedData = (T)JsonSerializer.Deserialize<T>(dataString, jsonSerializerOptions);
+					if (deserializedData is { })
+					{
+						return new SuccessResult<T>(deserializedData);
+					}
+				}
+				else if (streamResult is ErrorResult<Stream> error)
+				{
+					return new ErrorResult<T>(error.Message);
 				}
 
-				using var sr = new StreamReader(streamResult.Ok);
-				var dataString = sr.ReadToEnd();
-				deserializedData = (T)JsonSerializer.Deserialize<T>(dataString, jsonSerializerOptions);
+				// At the moment, this never happens because the two cases above are exhaustive.
+				var newError = "Error: Could not deserialize" + filename;
+				Debug.WriteLine(newError);
+				return new ErrorResult<T>(newError);
 			}
 			catch (IOException e)
 			{
 				Debug.WriteLine("File could not be read: " + filename);
 				Debug.WriteLine(e.Message);
-				return new Result<T>() { Err = e.Message };
+				return new ErrorResult<T>(e.Message);
 			}
 			catch (JsonException e)
 			{
 				Debug.WriteLine("JSON could not be deserialised: " + filename);
 				Debug.WriteLine(e.Message);
-				return new Result<T>() { Err = e.Message };
+				return new ErrorResult<T>(e.Message);
 			}
 			catch (Exception e)
 			{
 				Debug.WriteLine("Error: " + filename);
 				Debug.WriteLine(e.Message);
-				return new Result<T>() { Err = e.Message };
+				return new ErrorResult<T>(e.Message);
 			}
-
-			if (deserializedData is { })
-			{
-				return new Result<T>() {Ok = deserializedData};
-			}
-			
-			var error = "Error: Could not deserialize" + filename;
-			Debug.WriteLine(error);
-			return new Result<T>() { Err = error };
-
 		}
 
 		
-		public static Result<string> ReadFirstLineOfFileAsString(string filename)
+		public static JOSResult<string> ReadFirstLineOfFileAsString(string filename)
 		{
 			try
 			{
-				/*
-				var assembly = IntrospectionExtensions.GetTypeInfo(typeof(ReadingContext)).Assembly;
-				Stream? stream = assembly.GetManifestResourceStream("RightToAskClient.Resources." + filename);
-				if (stream is null)
-				{
-					Console.WriteLine("Could not find file: " + filename);
-					return new Result<string>() { Err = "Could not find file: " + filename};
-				}
-				*/
 				var streamResult = TryToGetFileStream(filename);
-				if (!string.IsNullOrEmpty(streamResult.Err))
+				if (streamResult.Success)
 				{
-					return new Result<string>() { Err = streamResult.Err };
-				}
-
-				using var sr = new StreamReader(streamResult.Ok);
-				var data = sr.ReadLine() ?? string.Empty;
-				if (!string.IsNullOrEmpty(data))
+					using var sr = new StreamReader(streamResult.Data);
+					var data = sr.ReadLine(); 
+					if (data != null)
+					{
+						return new SuccessResult<string>(data);
+					}
+				} else if (streamResult is ErrorResult<Stream> result)
 				{
-					return new Result<string>() { Ok = data };
+					return new ErrorResult<string>(result.Message);
 				}
 			}
 			catch (IOException e)
@@ -89,7 +83,7 @@ namespace RightToAskClient.Helpers
 				Debug.WriteLine(e.Message);
 			}
 
-			return new Result<string>() { Err = "Error reading file: " + filename };
+			return new ErrorResult<string>("Error reading file: " + filename);
 		}
 
 		public static void ReadDataFromCsv<T>(string filename, List<T> MPCollection, Func<string, T> parseLine)
@@ -121,17 +115,18 @@ namespace RightToAskClient.Helpers
 			}
 
 		}
-		private static Result<Stream> TryToGetFileStream(string filename)
+		private static JOSResult<Stream> TryToGetFileStream(string filename)
 		{
 				var assembly = IntrospectionExtensions.GetTypeInfo(typeof(ReadingContext)).Assembly;
 				var stream = assembly.GetManifestResourceStream("RightToAskClient.Resources." + filename);
 				if (stream is null)
 				{
 					Debug.WriteLine("Could not find file: " + filename);
-					return new Result<Stream>() { Err = "Could not find file: " + filename};
+					return new ErrorResult<Stream>("Could not find file: " + filename);
+					
 				}
 
-				return new Result<Stream> { Ok = stream };
+				return new SuccessResult<Stream>(stream);
 		}
 	}
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/NavigationUtils.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/NavigationUtils.cs
@@ -24,7 +24,7 @@ namespace RightToAskClient.Helpers
             //TODO** Seems unnecessary if our MPs are not initialized. 
             // Below, don't make the pages that are never used. The code is (somewhat redundant but)
             // correct but names are confusing.
-            var mpsSelectableListPage = new SelectableListPage(App.ReadingContext.Filters.AnsweringMPsListsMine, message);
+            var mpsSelectableListPage = new SelectableListPage(App.GlobalFilterChoices.AnsweringMPsListsMine, message);
             var nextPage = ListMPsFindFirstIfNotAlreadyKnown(mpsSelectableListPage);
             await Application.Current.MainPage.Navigation.PushAsync(nextPage);
         }
@@ -33,7 +33,7 @@ namespace RightToAskClient.Helpers
         {
             var message = "These are your MPs.  Select the one(s) who should raise the question in Parliament";
 
-            var mpsSelectableListPage = new SelectableListPage(App.ReadingContext.Filters.AskingMPsListsMine, message);
+            var mpsSelectableListPage = new SelectableListPage(App.GlobalFilterChoices.AskingMPsListsMine, message);
             await LaunchMPFindingAndSelectingPages(mpsSelectableListPage);
         }
 
@@ -65,7 +65,7 @@ namespace RightToAskClient.Helpers
         {
             var message = AppResources.SelectMPToAnswerText;
             var mpsPage =
-                new SelectableListPage(App.ReadingContext.Filters.AnsweringMPsListsNotMine, message);
+                new SelectableListPage(App.GlobalFilterChoices.AnsweringMPsListsNotMine, message);
             await Application.Current.MainPage.Navigation.PushAsync(mpsPage);
         }
 
@@ -73,14 +73,14 @@ namespace RightToAskClient.Helpers
         {
             var message = AppResources.SelectMPToRaiseText; 
             var mpsPage =
-                new SelectableListPage(App.ReadingContext.Filters.AskingMPsListsNotMine, message);
+                new SelectableListPage(App.GlobalFilterChoices.AskingMPsListsNotMine, message);
             await Application.Current.MainPage.Navigation.PushAsync(mpsPage);
         }
         
         public static async Task EditCommitteesClicked()
         {
             var committeeSelectableListPage
-                = new SelectableListPage(App.ReadingContext.Filters.CommitteeLists, AppResources.CommitteeText);
+                = new SelectableListPage(App.GlobalFilterChoices.CommitteeLists, AppResources.CommitteeText);
             await Application.Current.MainPage.Navigation.PushAsync(committeeSelectableListPage);
         }
         

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/NavigationUtils.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Helpers/NavigationUtils.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using RightToAskClient.Models;
 using RightToAskClient.Resx;
 using RightToAskClient.ViewModels;
 using RightToAskClient.Views;
@@ -49,9 +50,7 @@ namespace RightToAskClient.Helpers
 		 */
         public static Page ListMPsFindFirstIfNotAlreadyKnown(SelectableListPage mpsListPage)
         {
-            var thisParticipant = App.ReadingContext.ThisParticipant;
-
-            if (!thisParticipant.ElectoratesKnown)
+            if (!IndividualParticipant.ElectoratesKnown)
             {
                 var registrationPage = new RegisterPage2();
                 return registrationPage;
@@ -87,7 +86,7 @@ namespace RightToAskClient.Helpers
         
         public static async Task DoRegistrationCheck(BaseViewModel vm)
         {
-            if (!App.ReadingContext.ThisParticipant.IsRegistered)
+            if (!IndividualParticipant.IsRegistered)
             {
                 var popup = new TwoButtonPopup(vm, AppResources.MakeAccountQuestionText, AppResources.CreateAccountPopUpText, AppResources.CancelButtonText, AppResources.OKText);
                 _ = await App.Current.MainPage.Navigation.ShowPopupAsync(popup);

--- a/RightToAskClient/RightToAskClient/RightToAskClient/HttpClients/GeoscapeAddressRequestBuilder.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/HttpClients/GeoscapeAddressRequestBuilder.cs
@@ -7,7 +7,7 @@ namespace RightToAskClient.HttpClients
     public static class GeoscapeAddressRequestBuilder
     {
 		
-        public static Result<string> ApiKey { get; } = ReadGeoscapeApiKey();
+        public static JOSResult<string> ApiKey { get; } = ReadGeoscapeApiKey();
 
         static GeoscapeAddressRequestBuilder()
         {
@@ -24,7 +24,7 @@ namespace RightToAskClient.HttpClients
 	                               "&additionalProperties=commonwealthElectorate,stateElectorate,localGovernmentArea"; 
         }
         
-        private static Result<string> ReadGeoscapeApiKey()
+        private static JOSResult<string> ReadGeoscapeApiKey()
         {
 	        return FileIO.ReadFirstLineOfFileAsString(Constants.APIKeyFileName);
 		}

--- a/RightToAskClient/RightToAskClient/RightToAskClient/HttpClients/GeoscapeClient.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/HttpClients/GeoscapeClient.cs
@@ -22,27 +22,34 @@ namespace RightToAskClient.HttpClients
         
         private static readonly GenericHttpClient Client = new GenericHttpClient(SerializerOptions);
 
-        public static async Task<Result<GeoscapeAddressFeature>> GetFirstAddressData(string address)
+        public static async Task<JOSResult<GeoscapeAddressFeature>> GetFirstAddressData(string address)
         {
             var collection = await GetAddressDataAsync(address);
 
-            if (!string.IsNullOrEmpty(collection.Err))
+            if (collection.Failure)
             {
-                return new Result<GeoscapeAddressFeature> { Err = collection.Err };
+                var errorMessage = "Couldn't get first address.";
+                if (collection is ErrorResult<GeoscapeAddressFeatureCollection> errorResult)
+                {
+                    errorMessage = errorResult.Message;
+                }
+                return new ErrorResult<GeoscapeAddressFeature>(errorMessage);
             }
 
-            var addresses = collection.Ok.AddressDataList;
+            // collection.Success
+            var addresses = collection.Data.AddressDataList;
+            
             // I *think* this should never happen, because there should be a message if the
             // address list is empty, but better safe than sorry.
             if(addresses is null || addresses.Length == 0)
             {
-                return new Result<GeoscapeAddressFeature> { Err = "No addresses found" };
+                return new ErrorResult<GeoscapeAddressFeature>("No addresses found");
             }
 
-            return new Result<GeoscapeAddressFeature> { Ok = addresses[0] };
+            return new SuccessResult<GeoscapeAddressFeature>(addresses[0]);
         }
         
-        private static async Task<Result<GeoscapeAddressFeatureCollection>> GetAddressDataAsync(string address)
+        private static async Task<JOSResult<GeoscapeAddressFeatureCollection>> GetAddressDataAsync(string address)
         {
             var requestString = GeoscapeAddressRequestBuilder.BuildRequest(address);
 
@@ -52,7 +59,7 @@ namespace RightToAskClient.HttpClients
 
             if (!string.IsNullOrEmpty(GeoscapeAddressRequestBuilder.ApiKey.Err))
             {
-                return new Result<GeoscapeAddressFeatureCollection>() { Err = GeoscapeAddressRequestBuilder.ApiKey.Err };
+                return new ErrorResult<GeoscapeAddressFeatureCollection>(GeoscapeAddressRequestBuilder.ApiKey.Err);
             }
             
             // The ApiKey.OK _should_ be properly initialised to "" but this isn't guaranteed (despite the
@@ -67,28 +74,30 @@ namespace RightToAskClient.HttpClients
 
         // Geoscape-specific response interpretation.
         // TODO Find out if there's ever >1 message.
-        private static Result<GeoscapeAddressFeatureCollection> InterpretGeoscapeResponse(Result<GeoscapeAddressFeatureCollection> httpResponse)
+        private static JOSResult<GeoscapeAddressFeatureCollection> InterpretGeoscapeResponse(JOSResult<GeoscapeAddressFeatureCollection> httpResponse)
         {
-            if (!string.IsNullOrEmpty(httpResponse.Err))
+            if (httpResponse.Failure)
             {
                 return httpResponse;
             }
-            var errorMessages = httpResponse.Ok.Messages;
             
-            // If there are no messages, the response is OK.
+            // Successful http response, but there still might be errors from Geoscape.
+            var errorMessages = httpResponse.Data.Messages;
+            
+            // If there are no messages, the response is OK. Success.
             if (errorMessages is null || errorMessages.Length == 0 )
             {
-                return new Result<GeoscapeAddressFeatureCollection> { Ok = httpResponse.Ok };
+                return new SuccessResult<GeoscapeAddressFeatureCollection>(httpResponse.Data);
             }
             
             // If there's an error message, prettify the "no address matched" specific error, otherwise
             // just pass the error on.
             if (errorMessages[0] == "No address matched the query.")
             {
-                return new Result<GeoscapeAddressFeatureCollection> { Err = "Address not found - try again." };
+                return new ErrorResult<GeoscapeAddressFeatureCollection>("Address not found - try again.");
             }
 
-            return new Result<GeoscapeAddressFeatureCollection> { Err = errorMessages[0] };
+            return new ErrorResult<GeoscapeAddressFeatureCollection> (errorMessages[0]);
         }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/HttpClients/RTAClient.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/HttpClients/RTAClient.cs
@@ -255,6 +255,8 @@ namespace RightToAskClient.HttpClients
         // At the moment, this simply passes the information back to the user. We might perhaps want
         // to triage errors more carefully, or explain them to users better, or distinguish user-upload
         // errors from question-upload errors.
+        // This may also be much more elegantly implementable using other errors in the JOSResult type, rather than
+        // the triple now being returned.
         public static (bool isValid, string errorMessage, T returnedData) ValidateHttpResponse<T>(JOSResult<T> response, string messageTopic) where T : new()
         {
             if (response.Success)
@@ -272,8 +274,8 @@ namespace RightToAskClient.HttpClients
         }
 
         // overload because string doesn't satisfy T: new() 
-        /*
-        public static (bool isValid, string errorMessage, List<string> returnedData) ValidateHttpResponse(JOSResult<List<string>> response, string messageTopic) 
+        
+        public static (bool isValid, string errorMessage, string returnedData) ValidateHttpResponse(JOSResult<string> response, string messageTopic) 
         {
             if (response.Success)
             {
@@ -282,13 +284,12 @@ namespace RightToAskClient.HttpClients
             
             // response.Failure
             var errorMessage = messageTopic + "Server error: ";
-            if (response is ErrorResult<List<string>> errorResult)
+            if (response is ErrorResult<string> errorResult)
             {
                 errorMessage += errorResult.Message;
             }
-            return (false, errorMessage, new List<string>());
+            return (false, errorMessage, "");
         }
-        */
 
         // Tries to read server config, returns the url if there's a valid configuration file
         // specifying that that url is to be used.

--- a/RightToAskClient/RightToAskClient/RightToAskClient/HttpClients/RTAClient.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/HttpClients/RTAClient.cs
@@ -114,7 +114,7 @@ namespace RightToAskClient.HttpClients
 
         public static async Task<Result<string>> UpdateExistingUser(ServerUser existingReg)
         {
-            Debug.Assert(App.ReadingContext.ThisParticipant.IsRegistered);
+            Debug.Assert(IndividualParticipant.IsRegistered);
             return await SignAndSendDataToServer(existingReg, "user", EditUserUrl,
                 AppResources.AccountUpdateSigningError);
         }
@@ -160,7 +160,7 @@ namespace RightToAskClient.HttpClients
 
         public static async Task<Result<string>> RequestEmailValidation(RequestEmailValidationMessage msg, string email)
         {
-            var signedMsg =  App.ReadingContext.ThisParticipant.SignMessage(msg);
+            var signedMsg =  IndividualParticipant.SignMessage(msg);
             var serverSend = new RequestEmailValidationAPICall()
             {
                 email = email,
@@ -181,7 +181,7 @@ namespace RightToAskClient.HttpClients
         // "description" and "error string" are for reporting errors in upload and signing resp.
         private static async Task<Result<string>> SignAndSendDataToServer<T>(T data, string description, string url, string errorString)
         {
-            var signedUserMessage = App.ReadingContext.ThisParticipant.SignMessage(data);
+            var signedUserMessage = IndividualParticipant.SignMessage(data);
             if (!string.IsNullOrEmpty(signedUserMessage.signature))
             {
                 return await SendDataToServerVerifySignedResponse(signedUserMessage, description, url);

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Address.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Address.cs
@@ -15,7 +15,7 @@ namespace RightToAskClient.Models
                     var changed = SetProperty(ref _streetNumberAndName, value);
                     if (changed)
                     {
-                        App.ReadingContext.ThisParticipant.AddressUpdated = true;
+                        IndividualParticipant.AddressUpdated = true;
                     }
                 }
                 else
@@ -35,7 +35,7 @@ namespace RightToAskClient.Models
                     var changed = SetProperty(ref _cityOrSuburb, value);
                     if (changed)
                     {
-                        App.ReadingContext.ThisParticipant.AddressUpdated = true;
+                        IndividualParticipant.AddressUpdated = true;
                     }
                 }
                 else
@@ -55,7 +55,7 @@ namespace RightToAskClient.Models
                     var changed = SetProperty(ref _postCode, value);
                     if (changed)
                     {
-                        App.ReadingContext.ThisParticipant.AddressUpdated = true;
+                        IndividualParticipant.AddressUpdated = true;
                     }
                 }
                 else

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Address.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Address.cs
@@ -65,7 +65,7 @@ namespace RightToAskClient.Models
             }
         }
 
-        public Result<bool> SeemsValid()
+        public JOSResult<bool> SeemsValid()
         {
             var err = "";
             if (string.IsNullOrWhiteSpace(StreetNumberAndName))
@@ -83,10 +83,10 @@ namespace RightToAskClient.Models
 
             if (string.IsNullOrEmpty(err))
             {
-                return new Result<bool> { Ok = true };
+                return new SuccessResult<bool>(true);
             }
 
-            return new Result<bool> { Err = err };
+            return new ErrorResult<bool>(err);
         }
 
         public override string ToString()

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/FilterChoices.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/FilterChoices.cs
@@ -152,7 +152,7 @@ namespace RightToAskClient.Models
         // it's still possible for the question to go to 'my MP' when that person is their previous MP.
         public void UpdateMyMPLists()
         {
-	        AnsweringMPsListsMine.AllEntities = ParliamentData.FindAllMPsGivenElectorates(App.ReadingContext.ThisParticipant.RegistrationInfo.Electorates.ToList());
+	        AnsweringMPsListsMine.AllEntities = ParliamentData.FindAllMPsGivenElectorates(IndividualParticipant.ProfileData.RegistrationInfo.Electorates.ToList());
 	        AskingMPsListsMine.AllEntities = AnsweringMPsListsMine.AllEntities;
         }
 

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/IndividualParticipant.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/IndividualParticipant.cs
@@ -103,12 +103,13 @@ namespace RightToAskClient.Models
             ProfileData.RegistrationInfo.StateKnown = false; // Should already be the default.
             var stateString =  Preferences.Get(Constants.State, "");
             var state = ParliamentData.StateStringToEnum(stateString);
-            if (string.IsNullOrEmpty(state.Err) && !string.IsNullOrEmpty(stateString))
+            if (state.Success)
             {
                 ProfileData.RegistrationInfo.StateKnown = true;
-                ProfileData.RegistrationInfo.SelectedStateAsEnum = state.Ok;
+                ProfileData.RegistrationInfo.SelectedStateAsEnum = state.Data;
             }
 
+            // Use my public key from the client signature generation service.
 			ProfileData.RegistrationInfo.public_key = ClientSignatureGenerationService.InitSuccessful ? ClientSignatureGenerationService.MyPublicKey : "";
 		}
 

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/IndividualParticipant.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/IndividualParticipant.cs
@@ -1,7 +1,11 @@
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Org.BouncyCastle.Asn1.X509.SigI;
 using RightToAskClient.CryptoUtils;
 using RightToAskClient.Models.ServerCommsData;
+using Xamarin.Essentials;
 
 // This class represents a person who uses the
 // system and is not an MP or org representative.
@@ -10,58 +14,111 @@ namespace RightToAskClient.Models
 	// This represents the data we need to know *only* 
 	// about the user of this app, i.e. non-public data
 	// in addition to the public data in 'Person'
-	public class IndividualParticipant : Person 
+	public static class IndividualParticipant 
     {
-		public IndividualParticipant() 
-		{
-			ElectoratesKnown = false;
-			IsRegistered = false;
-			SigningKeyRetrieved = false;
-		}
+		// Init with empty data.
+		public static Person ProfileData = new Person("");
 
-		public bool IsRegistered { get; set; }
-		public bool SigningKeyRetrieved { get; set; }
-		public bool ElectoratesKnown { get; set; }
-		public bool AddressUpdated { get; set; }
-		public bool HasQuestions { get; set; }
-		public bool IsVerifiedMPAccount { get; set; }
-		public bool IsVerifiedMPStafferAccount { get; set; }
+		public static bool IsRegistered { get; set; }
+		public static bool ElectoratesKnown { get; set; }
+		public static bool AddressUpdated { get; set; }
+		public static bool HasQuestions { get; set; }
+		public static bool IsVerifiedMPAccount { get; set; }
+		public static bool IsVerifiedMPStafferAccount { get; set; }
 
-		private MP _MPRegisteredAs = new MP();
-		public MP MPRegisteredAs { 
+		private static MP _MPRegisteredAs = new MP();
+		public static MP MPRegisteredAs { 
 			get => _MPRegisteredAs;
 			set
 			{
 				_MPRegisteredAs = value;
-				OnPropertyChanged();
-				OnPropertyChanged("RegisteredMP");
+				// FIXME - not sure why OnPropertyChanged not compiling, but anyway perhaps we want the
+				// data from Registration anyway?
+				// OnPropertyChanged();
+				// OnPropertyChanged("RegisteredMP");
 			}
 		}
 
 		// needs to be accessible on a few pages and VMs so I put it here
-		public List<string> UpvotedQuestionIDs { get; set; } = new List<string>();
-		public List<string> ReportedQuestionIDs { get; set; } = new List<string>();
-		public List<string> RemovedQuestionIDs { get; set; } = new List<string>();
+		public static List<string> UpvotedQuestionIDs { get; set; } = new List<string>();
+		public static List<string> ReportedQuestionIDs { get; set; } = new List<string>();
+		public static List<string> RemovedQuestionIDs { get; set; } = new List<string>();
 
-		public ClientSignedUnparsed SignMessage<T>(T message)
+		public static ClientSignedUnparsed SignMessage<T>(T message)
 		{
-			return ClientSignatureGenerationService.SignMessage(message, RegistrationInfo.uid );
+			return ClientSignatureGenerationService.SignMessage(message, ProfileData.RegistrationInfo.uid );
 		}
 
-		public async Task<bool> Init()
+		public static void Init()
 		{
-			SigningKeyRetrieved = await ClientSignatureGenerationService.Init();
-			RegistrationInfo.public_key = ClientSignatureGenerationService.MyPublicKey;
-			return SigningKeyRetrieved;
+			// get account info from preferences
+            var registrationPref = Preferences.Get(Constants.RegistrationInfo, "");
+            if (!string.IsNullOrEmpty(registrationPref))
+            {
+                var registrationObj = JsonSerializer.Deserialize<ServerUser>(registrationPref);
+                ProfileData.RegistrationInfo 
+                    = registrationObj is null ? new Registration() : new Registration(registrationObj);
+                
+                // We actually need to check for the stored "IsRegistered" boolean, in case they tried to
+                // register but failed, for example because the server was offline.
+                // So we may have stored Registration data, but not have actually succeeded in uploading it.
+                IsRegistered = Preferences.Get(Constants.IsRegistered, false);
+                
+                // We have a problem if our stored registration is null but we think we registered successfully.
+                Debug.Assert(registrationObj != null || IsRegistered is false);
+                
+                // If we got electorates, let the app know to skip the Find My MPs step
+                // TODO We may want to distinguish between ElectoratesKnown and Electorates.Any, because
+                // the latter is true if only the state is known (Senate State being an electorate).
+                // At the moment, this will set ElectoratesKnown, in both the app and the preferences, when the person
+                // has selected their state, regardless of whether we know their electorate.
+                ElectoratesKnown = Preferences.Get(Constants.ElectoratesKnown, false);
+                
+                // Retrieve MP/staffer registration. Note that staffers have both the IsVerifiedMPAccount flag and the
+                // IsVerifiedMPStafferAccount flag set to true.
+                IsVerifiedMPAccount = Preferences.Get(Constants.IsVerifiedMPAccount, false);
+                if (IsVerifiedMPAccount)
+                {
+                    IsVerifiedMPStafferAccount =
+                        Preferences.Get(Constants.IsVerifiedMPStafferAccount, false);
+                    
+                    // Used when uploading an answer. 
+                    var MPRepresentingjson = Preferences.Get(Constants.MPRegisteredAs, "");
+                    if (!string.IsNullOrEmpty(MPRepresentingjson))
+                    {
+                        var MPRepresenting = JsonSerializer.Deserialize<MP>(MPRepresentingjson);
+                        if (MPRepresenting != null)
+                        {
+                            // See if we can find the registered MP in our existing list.
+                            // Using field-equality operator.
+                            // If so, just keep a pointer to it; if not, use a new MP object.
+                            MPRegisteredAs =
+                                ParliamentData.FindMPOrMakeNewOne(MPRepresenting);
+                        }
+                    }
+                }
+            }
+            
+            // If we already have stored a valid state, use it and set StateKnown to true.
+            ProfileData.RegistrationInfo.StateKnown = false; // Should already be the default.
+            var stateString =  Preferences.Get(Constants.State, "");
+            var state = ParliamentData.StateStringToEnum(stateString);
+            if (string.IsNullOrEmpty(state.Err) && !string.IsNullOrEmpty(stateString))
+            {
+                ProfileData.RegistrationInfo.StateKnown = true;
+                ProfileData.RegistrationInfo.SelectedStateAsEnum = state.Ok;
+            }
+
+			ProfileData.RegistrationInfo.public_key = ClientSignatureGenerationService.InitSuccessful ? ClientSignatureGenerationService.MyPublicKey : "";
 		}
 
-		public new bool Validate()
+		public static new bool Validate()
         {
 			var isValid = false;
 			// if they are registered, they need valid registration info
             if (IsRegistered)
             {
-				var validSuper = base.Validate();
+				var validSuper = ProfileData.Validate();
                 if (validSuper)
                 {
 					isValid = true;
@@ -75,7 +132,7 @@ namespace RightToAskClient.Models
 			// before  they have the chance to create an account
             else if (!IsRegistered && ElectoratesKnown)
             {
-				if (RegistrationInfo.StateKnown)
+				if (ProfileData.RegistrationInfo.StateKnown)
                 {
 					isValid = true;
 				}

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/JOSResult.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/JOSResult.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+
+/*
+ * By Josef Ottosson, from https://github.com/joseftw/jos.result
+ */
+namespace RightToAskClient.Models
+{
+    public abstract class JOSResult
+    {
+        public bool Success { get; protected set; }
+        public bool Failure => !Success;
+    }
+
+    public abstract class JOSResult<T> : JOSResult
+    {
+        private T _data;
+
+        protected JOSResult(T data)
+        {
+            Data = data;
+        }
+
+        public T Data
+        {
+            get => Success ? _data : throw new Exception($"You can't access .{nameof(Data)} when .{nameof(Success)} is false");
+            set => _data = value;
+        }
+    }
+
+    public class SuccessResult : JOSResult
+    {
+        public SuccessResult()
+        {
+            Success = true;
+        }
+    }
+
+    public class SuccessResult<T> : JOSResult<T>
+    {
+        public SuccessResult(T data) : base(data)
+        {
+            Success = true;
+        }
+
+        public static implicit operator SuccessResult(SuccessResult<T> successResult)
+        {
+            return new SuccessResult();
+        }
+    }
+
+    public class ErrorResult : JOSResult, IErrorResult
+    {
+        
+        public ErrorResult(string message) : this(message, Array.Empty<Error>())
+        {
+            
+        }
+
+        public ErrorResult(string message, IReadOnlyCollection<Error> errors)
+        {
+            Message = message;
+            Success = false;
+            Errors = errors ?? Array.Empty<Error>();
+        }
+
+        public string Message { get; }
+        public IReadOnlyCollection<Error> Errors { get; }
+
+        public virtual ErrorResult<T> ToGeneric<T>()
+        {
+            return new ErrorResult<T>(Message, Errors);
+        }
+    }
+
+    public class ErrorResult<T> : JOSResult<T>, IErrorResult
+    {
+        public ErrorResult(string message) : this(message, Array.Empty<Error>())
+        {
+        }
+
+        public ErrorResult(string message, IReadOnlyCollection<Error> errors) : base(default)
+        {
+            Message = message;
+            Success = false;
+            Errors = errors ?? Array.Empty<Error>();
+        }
+
+        public string Message { get; set; }
+        public IReadOnlyCollection<Error> Errors { get; }
+
+        public static implicit operator ErrorResult(ErrorResult<T> errorResult)
+        {
+            return new ErrorResult(errorResult.Message, errorResult.Errors);
+        }
+
+        public virtual ErrorResult<TType> ToGeneric<TType>()
+        {
+            return new ErrorResult<TType>(Message, Errors);
+        }
+    }
+
+    // TODO It's possible that we should have a variety of context-specific error results, e.g. for Geoscape / RTA server errors.
+    public class ServerUnreachableErrorResult : ErrorResult
+    {
+        public ServerUnreachableErrorResult(string message) : base(message)
+        {
+        }
+
+        public ServerUnreachableErrorResult(string message, IReadOnlyCollection<Error> errors) : base(message, errors)
+        {
+        }
+    }
+
+    public class ServerUnreachableErrorResult<T> : ErrorResult
+    {
+        public ServerUnreachableErrorResult(string message) : base(message)
+        {
+        }
+        
+        public ServerUnreachableErrorResult(string message, IReadOnlyCollection<Error> errors) : base(message, errors)
+        {
+        }
+    }
+
+    public class Error
+    {
+        public Error(string details) : this(null, details)
+        {
+        }
+
+        public Error(string code, string details)
+        {
+            Code = code;
+            Details = details;
+        }
+
+        public string Code { get; }
+        public string Details { get; }
+    }
+
+        
+    internal interface IErrorResult
+    {
+        string Message { get; }
+        IReadOnlyCollection<Error> Errors { get; }
+    }
+}

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Question.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Question.cs
@@ -231,19 +231,19 @@ namespace RightToAskClient.Models
 
             {
                 // can only upvote questions if you are registered
-                if (App.ReadingContext.ThisParticipant.IsRegistered)
+                if (IndividualParticipant.IsRegistered)
                 {
                     if (!AlreadyUpvoted)
                     {
                         UpVotes += 1;
                         AlreadyUpvoted = true;
-                        App.ReadingContext.ThisParticipant.UpvotedQuestionIDs.Add(QuestionId);
+                        IndividualParticipant.UpvotedQuestionIDs.Add(QuestionId);
                     }
                     else
                     {
                         UpVotes -= 1;
                         AlreadyUpvoted = false;
-                        App.ReadingContext.ThisParticipant.UpvotedQuestionIDs.Remove(QuestionId);
+                        IndividualParticipant.UpvotedQuestionIDs.Remove(QuestionId);
                     }
                 }
                 else
@@ -276,11 +276,11 @@ namespace RightToAskClient.Models
                 AlreadyReported = !AlreadyReported;
                 if (AlreadyReported)
                 {
-                    App.ReadingContext.ThisParticipant.ReportedQuestionIDs.Add(QuestionId);
+                    IndividualParticipant.ReportedQuestionIDs.Add(QuestionId);
                 }
                 else
                 {
-                    App.ReadingContext.ThisParticipant.ReportedQuestionIDs.Remove(QuestionId);
+                    IndividualParticipant.ReportedQuestionIDs.Remove(QuestionId);
                 }
             });
             PopupApproveCommand = new Command(() =>
@@ -367,7 +367,7 @@ namespace RightToAskClient.Models
                     else if (entity.AsMP != null)
                     {
                         // If the MP is one of mine, add it to AnsweringMPsMine
-                        var myMPs = ParliamentData.FindAllMPsGivenElectorates(App.ReadingContext.ThisParticipant.RegistrationInfo.Electorates.ToList());
+                        var myMPs = ParliamentData.FindAllMPsGivenElectorates(IndividualParticipant.ProfileData.RegistrationInfo.Electorates.ToList());
                         if (!CanFindInListBThenAddToListA<MP>(entity.AsMP, Filters.SelectedAnsweringMPsMine, myMPs))
                         {
                             // otherwise, try to find it in AllMPs
@@ -399,7 +399,7 @@ namespace RightToAskClient.Models
                     if (entity.AsMP != null)
                     {
                         // If the MP is one of mine, add it to AskingMPsMine
-                        var myMPs = ParliamentData.FindAllMPsGivenElectorates(App.ReadingContext.ThisParticipant.RegistrationInfo.Electorates.ToList());
+                        var myMPs = ParliamentData.FindAllMPsGivenElectorates(IndividualParticipant.ProfileData.RegistrationInfo.Electorates.ToList());
                         if (!CanFindInListBThenAddToListA<MP>(entity.AsMP, Filters.SelectedAskingMPsMine, myMPs))
                         {
                             // otherwise, try to find it in AllMPs
@@ -484,13 +484,11 @@ namespace RightToAskClient.Models
 
         public void AddAnswer(string answer)
         {
-            var me = App.ReadingContext.ThisParticipant;
-
             Updates.answers = new List<QuestionAnswer>()
             {
                 new QuestionAnswer()
                 {
-                    mp = new MPId(me.MPRegisteredAs),
+                    mp = new MPId(IndividualParticipant.MPRegisteredAs),
                     answer = answer
                 }
             };

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Question.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Question.cs
@@ -332,9 +332,9 @@ namespace RightToAskClient.Models
                 foreach (var link in serverQuestion.hansard_link)
                 {
                     var possibleUrl = ParliamentData.StringToValidParliamentaryUrl(link?.url ?? "");
-                    if (string.IsNullOrEmpty(possibleUrl.Err))
+                    if (possibleUrl.Success)
                     {
-                        HansardLink.Add(possibleUrl.Ok);
+                        HansardLink.Add(possibleUrl.Data);
                     }
                 }
             }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
@@ -5,27 +5,7 @@ namespace RightToAskClient.Models
 {
 	public class ReadingContext : ObservableObject
 	{
-		private bool _dontShowFirstTimeReadingPopup;
-		public bool DontShowFirstTimeReadingPopup
-		{
-			get => _dontShowFirstTimeReadingPopup;
-			set => SetProperty(ref _dontShowFirstTimeReadingPopup, value);
-		}
-
 		public bool ShowHowToPublishPopup { get; set; } = true;
-
-		// public event PropertyChangedEventHandler? PropertyChanged;
-
-        public ReadingContext()
-        {
-	        // Also initialises signing keys etc.
-	        // Consider awaiting. I don't think so, though, because there's no reason everything else should wait for it.
-	        // ThisParticipant.Init();
-        }
-        
-		// Things about this user.
-		// These selections are made at registration, or at 'complete registration.'
-		// public IndividualParticipant ThisParticipant { get; set; } = new IndividualParticipant();
 
 		private FilterChoices _filters = new FilterChoices();
 

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
@@ -5,8 +5,6 @@ namespace RightToAskClient.Models
 {
 	public class ReadingContext : ObservableObject
 	{
-		public bool ShowHowToPublishPopup { get; set; } = true;
-
 		private FilterChoices _filters = new FilterChoices();
 
 		public FilterChoices Filters

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
@@ -5,20 +5,6 @@ namespace RightToAskClient.Models
 {
 	public class ReadingContext : ObservableObject
 	{
-		// Used for determining if the user is in the process of trying to draft a question, or if they are browsing on the reading page.
-		// The reading page can be accessed from various ways from the main page (with some filters already filled in)
-		// Or from within the question drafting flow for finding a similar question to upvote instead of continuing with the drafted question for submission.
-		private bool _isReadingOnly;
-		public bool IsReadingOnly 
-		{ 
-			get => _isReadingOnly;
-			set
-			{
-				_isReadingOnly = value;
-				OnPropertyChanged();
-			}
-		}
-
 		private bool _dontShowFirstTimeReadingPopup;
 		public bool DontShowFirstTimeReadingPopup
 		{

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/ReadingContext.cs
@@ -34,12 +34,12 @@ namespace RightToAskClient.Models
         {
 	        // Also initialises signing keys etc.
 	        // Consider awaiting. I don't think so, though, because there's no reason everything else should wait for it.
-	        ThisParticipant.Init();
+	        // ThisParticipant.Init();
         }
         
 		// Things about this user.
 		// These selections are made at registration, or at 'complete registration.'
-		public IndividualParticipant ThisParticipant { get; set; } = new IndividualParticipant();
+		// public IndividualParticipant ThisParticipant { get; set; } = new IndividualParticipant();
 
 		private FilterChoices _filters = new FilterChoices();
 

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
@@ -45,7 +45,7 @@ namespace RightToAskClient.Models
             set 
             {
                 SetProperty(ref _electorates, value.ToList());
-                App.ReadingContext.Filters.UpdateMyMPLists();
+                App.GlobalFilterChoices.UpdateMyMPLists();
             } 
         }
 
@@ -97,7 +97,7 @@ namespace RightToAskClient.Models
             _electorates.RemoveAll(e => e.chamber == newElectorate.chamber);
             _electorates.Insert(0, newElectorate);
             OnPropertyChanged("electorates");
-            App.ReadingContext.Filters.UpdateMyMPLists();
+            App.GlobalFilterChoices.UpdateMyMPLists();
         }
 
         private void Electorates_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
@@ -105,7 +105,7 @@ namespace RightToAskClient.Models
             throw new NotImplementedException();
         }
 
-        public JOSResult<bool> IsValid()
+        public JOSResult IsValid()
         {
             var errorFields = new List<string>();
 
@@ -120,10 +120,10 @@ namespace RightToAskClient.Models
 
             if (errorFields.IsNullOrEmpty() || errorFields.SequenceEqual(new List<string> { "electorates" }))
             {
-                return new SuccessResult<bool>(true);
+                return new SuccessResult();
             }
 
-            return new ErrorResult<bool>("Please complete " + string.Join(" and ", errorFields));
+            return new ErrorResult("Please complete " + string.Join(" and ", errorFields));
         }
 
         public bool Validate()

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
@@ -174,8 +174,8 @@ namespace RightToAskClient.Models
                 successState =
                     (ParliamentData.StateEnum)Enum.ToObject(typeof(ParliamentData.StateEnum), selectedStateAsInt);
                 successBool = true;
-                App.ReadingContext.ThisParticipant.RegistrationInfo.StateKnown = successBool;
-                App.ReadingContext.ThisParticipant.RegistrationInfo.SelectedStateAsEnum = successState;
+                IndividualParticipant.ProfileData.RegistrationInfo.StateKnown = successBool;
+                IndividualParticipant.ProfileData.RegistrationInfo.SelectedStateAsEnum = successState;
                 Preferences.Set(Constants.State, successState.ToString());
             }
 

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/Registration.cs
@@ -68,10 +68,10 @@ namespace RightToAskClient.Models
             display_name = input.display_name ?? "";
             public_key = input.public_key ?? "";
             var stateResult = ParliamentData.StateStringToEnum(input.state ?? "");
-            if (string.IsNullOrEmpty(stateResult.Err))
+            if (stateResult.Success)
             {
                 StateKnown = true;
-                SelectedStateAsEnum = stateResult.Ok;
+                SelectedStateAsEnum = stateResult.Data;
             }
             else
             {
@@ -105,7 +105,7 @@ namespace RightToAskClient.Models
             throw new NotImplementedException();
         }
 
-        public Result<bool> IsValid()
+        public JOSResult<bool> IsValid()
         {
             var errorFields = new List<string>();
 
@@ -120,12 +120,10 @@ namespace RightToAskClient.Models
 
             if (errorFields.IsNullOrEmpty() || errorFields.SequenceEqual(new List<string> { "electorates" }))
             {
-                return new Result<bool>() { Ok = true };
+                return new SuccessResult<bool>(true);
             }
-            return new Result<bool>()
-            {
-                Err = "Please complete " + string.Join(" and ", errorFields)
-            };
+
+            return new ErrorResult<bool>("Please complete " + string.Join(" and ", errorFields));
         }
 
         public bool Validate()

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/SelectableList.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/SelectableList.cs
@@ -2,11 +2,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Xamarin.CommunityToolkit.ObjectModel;
 
 namespace RightToAskClient.Models
 {
 
-    public class SelectableList<T> : INotifyPropertyChanged // where T: Entity
+    public class SelectableList<T> : ObservableObject //INotifyPropertyChanged // where T: Entity
     {
         private IEnumerable<T> _allEntities;
 
@@ -43,6 +44,7 @@ namespace RightToAskClient.Models
             _selectedEntities = selectedEntities ?? new ObservableCollection<T>();
         }
 
+        /*
         public event PropertyChangedEventHandler? PropertyChanged;
 
         [NotifyPropertyChangedInvocator]
@@ -50,5 +52,6 @@ namespace RightToAskClient.Models
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
+        */
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/ServerCommsData/ClientSignedUnparsed.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/ServerCommsData/ClientSignedUnparsed.cs
@@ -21,10 +21,10 @@ namespace RightToAskClient.Models.ServerCommsData
             var isValid = false;
             var hasInvalidData = false;
             // if user is me, check for valid signature
-            if (user == App.ReadingContext.ThisParticipant.RegistrationInfo.uid)
+            if (user == IndividualParticipant.ProfileData.RegistrationInfo.uid)
             {
                 var signaturebytes = Convert.FromBase64String(signature);
-                var ClientPublicKey = new Ed25519PublicKeyParameters(Convert.FromBase64String(App.ReadingContext.ThisParticipant.RegistrationInfo.public_key));
+                var ClientPublicKey = new Ed25519PublicKeyParameters(Convert.FromBase64String(IndividualParticipant.ProfileData.RegistrationInfo.public_key));
                 var validSig = SignatureVerificationService.VerifySignature(message, signaturebytes, ClientPublicKey);
                 if (validSig)
                 {

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/ServerCommsData/ServerResult.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/ServerCommsData/ServerResult.cs
@@ -1,11 +1,12 @@
-namespace RightToAskClient.Models
+namespace RightToAskClient.Models.ServerCommsData
 {
-    public class Result<T>
+    public class ServerResult<T>
     {
         // TODO This is non-ideal because I can't declare a type
         // parameter to be nullable. 
         // Look at whether more recent versions of the language have nicer ways of doing this,
         // e.g. https://stackoverflow.com/questions/59702550/c-sharp-8-nullables-and-result-container
+        // Or consider adopting https://josef.codes/my-take-on-the-result-class-in-c-sharp/
         public T Ok { get; set; }
         public string? Err { get; set; }
     }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/UpdatableCommitteesAndHearingsData.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/UpdatableCommitteesAndHearingsData.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using RightToAskClient.HttpClients;
+using RightToAskClient.Models.ServerCommsData;
 
 namespace RightToAskClient.Models
 {
@@ -35,7 +36,7 @@ namespace RightToAskClient.Models
             }
 
             // serverCommitteeList.Failure
-            if (serverCommitteeList is ErrorResult errorResult)
+            if (serverCommitteeList is ErrorResult<List<CommitteeInfo>> errorResult)
             {
                 return new ErrorResult(errorResult.Message);
             }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/UpdatableCommitteesAndHearingsData.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/UpdatableCommitteesAndHearingsData.cs
@@ -16,27 +16,31 @@ namespace RightToAskClient.Models
         public bool IsInitialised { get; private set; }
 
 
-        public async Task<Result<bool>> TryInitialisingFromServer()
+        public async Task<JOSResult> TryInitialisingFromServer()
         {
             var serverCommitteeList = await RTAClient.GetCommitteeData();
             if (serverCommitteeList is null)
             {
-                return new Result<bool>() { Err = "Could not reach server." };
+                // TODO Consider changing to a specific 'server unreachable' error.
+                return new ErrorResult<bool>("Could not reach server.");
             }
 
             // Success. Set list of selectable committees and update filters to reflect new list.
-            if (string.IsNullOrEmpty(serverCommitteeList.Err))
+            if (serverCommitteeList.Success)
             {
                 IsInitialised = true;
-                Committees = serverCommitteeList.Ok.Select(com => new Committee(com)).ToList();
+                Committees = serverCommitteeList.Data.Select(com => new Committee(com)).ToList();
 				// App.ReadingContext.Filters.InitSelectableLists();
-                return new Result<bool>() { Ok = true };
+                return new SuccessResult();
             }
 
-            return new Result<bool>()
+            // serverCommitteeList.Failure
+            if (serverCommitteeList is ErrorResult errorResult)
             {
-                Err = serverCommitteeList.Err
-            };
+                return new ErrorResult(errorResult.Message);
+            }
+
+            return new ErrorResult("Couldn't get committee and hearing data from server.");
         }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Models/UpdatableParliamentAndMPData.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Models/UpdatableParliamentAndMPData.cs
@@ -66,7 +66,7 @@ namespace RightToAskClient.Models
 		// Find all the MPs representing a certain electorate.
 		public List<MP> GetMPsRepresentingElectorate(ElectorateWithChamber queryElectorate)
 		{
-			var mps = _allMPsData.mps?.Where(mp => mp.electorate.chamber == queryElectorate.chamber
+			var mps = _allMPsData.mps?.Where(mp => mp?.electorate?.chamber == queryElectorate.chamber
 			                             && mp.electorate.region.Equals(queryElectorate.region,
 				                             StringComparison.OrdinalIgnoreCase));
 			return new List<MP>(mps ?? new MP[]{});
@@ -158,8 +158,8 @@ namespace RightToAskClient.Models
 
 		public List<string> ListElectoratesInChamber(ParliamentData.Chamber chamber)
 		{
-			return new List<string>(AllMPs.Where(mp => mp.electorate.chamber == chamber)
-				.Select(mp => mp.electorate.region).Distinct().OrderBy(r=>r));
+			return new List<string>(AllMPs.Where(mp => mp?.electorate?.chamber == chamber)
+				.Select(mp => mp?.electorate?.region).Where(s=> !String.IsNullOrEmpty(s)).Distinct().OrderBy(r=>r));
 		}
 	}
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
@@ -159,6 +159,12 @@ namespace RightToAskClient.Resx {
             }
         }
         
+        internal static string CouldNotFindUser {
+            get {
+                return ResourceManager.GetString("CouldNotFindUser", resourceCulture);
+            }
+        }
+        
         internal static string CompleteAccountCreationButtonText {
             get {
                 return ResourceManager.GetString("CompleteAccountCreationButtonText", resourceCulture);
@@ -396,6 +402,18 @@ namespace RightToAskClient.Resx {
         internal static string InvalidAddress {
             get {
                 return ResourceManager.GetString("InvalidAddress", resourceCulture);
+            }
+        }
+        
+        internal static string InvalidHansardLink {
+            get {
+                return ResourceManager.GetString("InvalidHansardLink", resourceCulture);
+            }
+        }
+        
+        internal static string InvalidRegistration {
+            get {
+                return ResourceManager.GetString("InvalidRegistration", resourceCulture);
             }
         }
         

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
@@ -273,6 +273,12 @@ namespace RightToAskClient.Resx {
             }
         }
         
+        internal static string ErrorFindingAddress {
+            get {
+                return ResourceManager.GetString("ErrorFindingAddress", resourceCulture);
+            }
+        }
+        
         internal static string ExpiringSoonButtonText {
             get {
                 return ResourceManager.GetString("ExpiringSoonButtonText", resourceCulture);
@@ -384,6 +390,12 @@ namespace RightToAskClient.Resx {
         internal static string IncludeUnansweredQuestions {
             get {
                 return ResourceManager.GetString("IncludeUnansweredQuestions", resourceCulture);
+            }
+        }
+        
+        internal static string InvalidAddress {
+            get {
+                return ResourceManager.GetString("InvalidAddress", resourceCulture);
             }
         }
         

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
@@ -174,6 +174,9 @@
   <data name="ClickForFiltersText" xml:space="preserve">
     <value>Click to show Filters</value>
   </data>
+  <data name="CouldNotFindUser" xml:space="preserve">
+    <value>Could not find user on the server: </value>
+  </data>
   <data name="CompleteAccountCreationButtonText" xml:space="preserve">
     <value>Complete Account Creation</value>
   </data>
@@ -293,6 +296,12 @@
   </data>
   <data name="InvalidAddress" xml:space="preserve">
     <value>Invalid address</value>
+  </data>
+  <data name="InvalidHansardLink" xml:space="preserve">
+    <value>Invalid Hansard Link</value>
+  </data>
+  <data name="InvalidRegistration" xml:space="preserve">
+    <value>Invalid registration</value>
   </data>
   <data name="KeepQuestionButtonText" xml:space="preserve">
     <value>Publish</value>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
@@ -231,6 +231,9 @@
   <data name="EmailTitle" xml:space="preserve">
     <value>Email</value>
   </data>
+  <data name="ErrorFindingAddress" xml:space="preserve">
+    <value>Error finding address</value>
+  </data>
   <data name="ExpiringSoonButtonText" xml:space="preserve">
     <value>Expiring Soon</value>
   </data>
@@ -287,6 +290,9 @@
   </data>
   <data name="IncludeUnansweredQuestions" xml:space="preserve">
     <value>Include questions with no answer? </value>
+  </data>
+  <data name="InvalidAddress" xml:space="preserve">
+    <value>Invalid address</value>
   </data>
   <data name="KeepQuestionButtonText" xml:space="preserve">
     <value>Publish</value>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/FilterViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/FilterViewModel.cs
@@ -16,12 +16,14 @@ namespace RightToAskClient.ViewModels
         /* FIXME It would make a lot more sense to set this up with either an empty constructor
          * (for the ReadingContext filters) or an explicit/new one (for a fresh question etc).
          * The instance is only used in the Metadata page. Not clear that this is logically correct.
+         * Why not just use the data from the GlobalFilters, since we only ever access the Metadata
+         * page with those filters?
          */
         private static FilterViewModel? _instance;
         public static FilterViewModel Instance => _instance ??= new FilterViewModel();
 
         // properties
-        private static FilterChoices GlobalFilterChoices => App.ReadingContext.Filters;
+        // private static FilterChoices GlobalFilterChoices => App.ReadingContext.Filters;
 
         public ClickableListViewModel AnsweringMPsOther { get; }
         public ClickableListViewModel AnsweringMPsMine { get; }
@@ -61,21 +63,13 @@ namespace RightToAskClient.ViewModels
         public bool OthersCanAddAnswerers
         {
             get => QuestionViewModel.Instance.OthersCanAddQuestionAnswerers; 
-            set =>
-                // SetProperty(ref _othersCanAddAnswerers, value);
-                // QuestionViewModel.Instance.WhoShouldAnswerItPermissions = _othersCanAddAnswerers ? RTAPermissions.Others : RTAPermissions.WriterOnly;
-                QuestionViewModel.Instance.OthersCanAddQuestionAnswerers = value;
-            // OnPropertyChanged();
+            set => QuestionViewModel.Instance.OthersCanAddQuestionAnswerers = value;
         }
 
         public bool OthersCanAddAskers
         {
             get => QuestionViewModel.Instance.OthersCanAddQuestionAskers; 
-            set =>
-                // SetProperty(ref _othersCanAddAskers, value);
-                // QuestionViewModel.Instance.WhoShouldAskItPermissions = _othersCanAddAskers ? RTAPermissions.Others : RTAPermissions.WriterOnly;
-                QuestionViewModel.Instance.OthersCanAddQuestionAskers = value;
-            // OnPropertyChanged();
+            set => QuestionViewModel.Instance.OthersCanAddQuestionAskers = value;
         }
 
         private bool _answerInApp;
@@ -98,7 +92,7 @@ namespace RightToAskClient.ViewModels
                 var changed = SetProperty(ref _keyword, value);
                 if (changed)
                 {
-                    App.ReadingContext.Filters.SearchKeyword = _keyword;
+                    App.GlobalFilterChoices.SearchKeyword = _keyword;
                 }
             }
         }
@@ -130,7 +124,7 @@ namespace RightToAskClient.ViewModels
             Title = AppResources.AdvancedSearchButtonText; 
             ReinitData(); // to set the display strings
 
-            AnsweringMPsMine = new ClickableListViewModel(GlobalFilterChoices.AnsweringMPsListsMine)
+            AnsweringMPsMine = new ClickableListViewModel(App.GlobalFilterChoices.AnsweringMPsListsMine)
             {
                 // FIXME This isn't quite right when the MPs are not known - seems to push a 
                 // list to choose from and then go to a reading page, rather than popping on completion
@@ -145,7 +139,7 @@ namespace RightToAskClient.ViewModels
                 }),
                 Heading = AppResources.MyMPButtonText
             };
-            AnsweringMPsOther = new ClickableListViewModel(GlobalFilterChoices.AnsweringMPsListsNotMine)
+            AnsweringMPsOther = new ClickableListViewModel(App.GlobalFilterChoices.AnsweringMPsListsNotMine)
             {
                 EditListCommand = new Command(() =>
                 {
@@ -156,7 +150,7 @@ namespace RightToAskClient.ViewModels
                 }),
                 Heading = AppResources.OtherMP,
             };
-            AnsweringAuthorities = new ClickableListViewModel(GlobalFilterChoices.AuthorityLists)
+            AnsweringAuthorities = new ClickableListViewModel(App.GlobalFilterChoices.AuthorityLists)
             {
                 EditListCommand = new Command(() =>
                 {
@@ -167,7 +161,7 @@ namespace RightToAskClient.ViewModels
                 }),
                 Heading = AppResources.AuthorityLabel,
             };
-            AskingMPsMine = new ClickableListViewModel(GlobalFilterChoices.AskingMPsListsMine)
+            AskingMPsMine = new ClickableListViewModel(App.GlobalFilterChoices.AskingMPsListsMine)
             {
                 EditListCommand = new Command(() =>
                 {
@@ -178,7 +172,7 @@ namespace RightToAskClient.ViewModels
                 }),
                 Heading = AppResources.MyMPButtonText
             };
-            AskingMPsOther = new ClickableListViewModel(GlobalFilterChoices.AskingMPsListsNotMine)
+            AskingMPsOther = new ClickableListViewModel(App.GlobalFilterChoices.AskingMPsListsNotMine)
             {
                 EditListCommand = new Command(() =>
                 {
@@ -189,7 +183,7 @@ namespace RightToAskClient.ViewModels
                 }),
                 Heading = AppResources.OtherMP
             };
-            Committees = new ClickableListViewModel(GlobalFilterChoices.CommitteeLists)
+            Committees = new ClickableListViewModel(App.GlobalFilterChoices.CommitteeLists)
             {
                 EditListCommand = new Command(() =>
                 {
@@ -284,7 +278,7 @@ namespace RightToAskClient.ViewModels
         public void ReinitData()
         {
             // set the keyword
-            Keyword = App.ReadingContext.Filters.SearchKeyword;
+            Keyword = App.GlobalFilterChoices.SearchKeyword;
 
             // TODO Ideally, we shouldn't have to do this manually,
             // but I don't see a more elegant way at the moment.
@@ -318,7 +312,7 @@ namespace RightToAskClient.ViewModels
             var message = "Choose others to add";
 
             var departmentExploringPage
-                = new SelectableListPage(App.ReadingContext.Filters.AuthorityLists, message);
+                = new SelectableListPage(App.GlobalFilterChoices.AuthorityLists, message);
             await Application.Current.MainPage.Navigation.PushAsync(departmentExploringPage);
         }
 
@@ -364,7 +358,7 @@ namespace RightToAskClient.ViewModels
             {
                 var matchingParticipants = searchResults.Ok.Select(u => new Person(u)).ToList();
                 _selectableParticipants = new SelectableList<Person>(matchingParticipants);
-                App.ReadingContext.Filters.QuestionWriterLists = _selectableParticipants;
+                App.GlobalFilterChoices.QuestionWriterLists = _selectableParticipants;
                 var participantsSearchSelectionPage
                     = new SelectableListPage(_selectableParticipants, AppResources.ChooseParticipantsText, true);
                 await Application.Current.MainPage.Navigation.PushAsync(participantsSearchSelectionPage).ContinueWith( (_) =>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/FilterViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/FilterViewModel.cs
@@ -8,6 +8,7 @@ using Xamarin.Forms;
 using System.Threading.Tasks;
 using RightToAskClient.Helpers;
 using RightToAskClient.HttpClients;
+using RightToAskClient.Models.ServerCommsData;
 
 namespace RightToAskClient.ViewModels
 {
@@ -346,17 +347,21 @@ namespace RightToAskClient.ViewModels
             var searchString = QuestionWriterSearchText;
 
             var searchResults = await RTAClient.SearchUser(searchString);
-            if (!string.IsNullOrEmpty(searchResults.Err))
+            if (searchResults.Failure)
             {
-                ReportLabelText = searchResults.Err ?? string.Empty;
+                ReportLabelText = "Error searching for user " + searchString + ". ";
+                if (searchResults is ErrorResult<List<ServerUser>> errorResult)
+                {
+                    ReportLabelText += errorResult;
+                }
             }
-            else if (!searchResults.Ok.Any())
+            else if (!searchResults.Data.Any())
             {
                 ReportLabelText = AppResources.NoParticipantsFoundText;
             }
             else
             {
-                var matchingParticipants = searchResults.Ok.Select(u => new Person(u)).ToList();
+                var matchingParticipants = searchResults.Data.Select(u => new Person(u)).ToList();
                 _selectableParticipants = new SelectableList<Person>(matchingParticipants);
                 App.GlobalFilterChoices.QuestionWriterLists = _selectableParticipants;
                 var participantsSearchSelectionPage

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/FindMPsViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/FindMPsViewModel.cs
@@ -20,7 +20,7 @@ namespace RightToAskClient.ViewModels
         #region Properties
 
         private Address _address = new Address();
-        private readonly Registration _registration = App.ReadingContext.ThisParticipant.RegistrationInfo;
+        private readonly Registration _registration = IndividualParticipant.ProfileData.RegistrationInfo;
         public Address Address
         {
             get => _address;
@@ -82,7 +82,7 @@ namespace RightToAskClient.ViewModels
             }
         }
         public List<string> StatePicker => ParliamentData.StateStrings;
-        // private string _statePickerTitle = String.IsNullOrEmpty(App.ReadingContext.ThisParticipant.RegistrationInfo.State) ? "Choose State or Territory" : App.ReadingContext.ThisParticipant.RegistrationInfo.State;
+        // private string _statePickerTitle = String.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.State) ? "Choose State or Territory" : IndividualParticipant.ProfileData.RegistrationInfo.State;
         public string StatePickerTitle =>
             _registration.StateKnown
                 ? _registration.SelectedStateAsEnum.ToString()
@@ -137,9 +137,9 @@ namespace RightToAskClient.ViewModels
         public ObservableCollection<string> AllStateChoosableElectorates { get; } = new ObservableCollection<string>();
 
         private string _stateChoosableElectorateHeader 
-            =  App.ReadingContext.ThisParticipant.RegistrationInfo.SelectedStateAsEnum == ParliamentData.StateEnum.TAS
-            ? $"State Legislative Council Electorate: {App.ReadingContext.ThisParticipant.StateUpperHouseElectorate:F0}"
-            : $"State Legislative Assembly Electorate: {App.ReadingContext.ThisParticipant.StateLowerHouseElectorate:F0}";
+            =  IndividualParticipant.ProfileData.RegistrationInfo.SelectedStateAsEnum == ParliamentData.StateEnum.TAS
+            ? $"State Legislative Council Electorate: {IndividualParticipant.ProfileData.StateUpperHouseElectorate:F0}"
+            : $"State Legislative Assembly Electorate: {IndividualParticipant.ProfileData.StateLowerHouseElectorate:F0}";
 
         public string StateChoosableElectorateHeader
         {
@@ -149,9 +149,9 @@ namespace RightToAskClient.ViewModels
 
         private string _stateChoosableElectorate
             = "Select: " + 
-            (App.ReadingContext.ThisParticipant.RegistrationInfo.SelectedStateAsEnum == ParliamentData.StateEnum.TAS
-                    ? App.ReadingContext.ThisParticipant.StateUpperHouseElectorate
-                    : App.ReadingContext.ThisParticipant.StateLowerHouseElectorate);
+            (IndividualParticipant.ProfileData.RegistrationInfo.SelectedStateAsEnum == ParliamentData.StateEnum.TAS
+                    ? IndividualParticipant.ProfileData.StateUpperHouseElectorate
+                    : IndividualParticipant.ProfileData.StateLowerHouseElectorate);
 
         public string StateChoosableElectorate
         {
@@ -161,7 +161,7 @@ namespace RightToAskClient.ViewModels
         }
 
         private string _stateInferredElectorateHeader  
-            =  App.ReadingContext.ThisParticipant.RegistrationInfo.SelectedStateAsEnum == ParliamentData.StateEnum.TAS
+            =  IndividualParticipant.ProfileData.RegistrationInfo.SelectedStateAsEnum == ParliamentData.StateEnum.TAS
             ? "State Legislative Assembly Electorate: " : "State Legislative Council Electorate: ";
         
         public string StateInferredElectorateHeader
@@ -171,9 +171,9 @@ namespace RightToAskClient.ViewModels
         }
         
         private string _stateInferredElectorate  
-            =  App.ReadingContext.ThisParticipant.RegistrationInfo.SelectedStateAsEnum == ParliamentData.StateEnum.TAS
-            ? App.ReadingContext.ThisParticipant.StateLowerHouseElectorate 
-            : App.ReadingContext.ThisParticipant.StateUpperHouseElectorate;
+            =  IndividualParticipant.ProfileData.RegistrationInfo.SelectedStateAsEnum == ParliamentData.StateEnum.TAS
+            ? IndividualParticipant.ProfileData.StateLowerHouseElectorate 
+            : IndividualParticipant.ProfileData.StateUpperHouseElectorate;
         
         public string StateInferredElectorate
         {
@@ -182,7 +182,7 @@ namespace RightToAskClient.ViewModels
         }
         
         private string _federalElectoratePickerTitle =
-            $"Select: {App.ReadingContext.ThisParticipant.CommonwealthElectorate:F0}";
+            $"Select: {IndividualParticipant.ProfileData.CommonwealthElectorate:F0}";
         public string FederalElectoratePickerTitle
         {
             get => _federalElectoratePickerTitle;
@@ -215,28 +215,28 @@ namespace RightToAskClient.ViewModels
             ShowKnowElectoratesFrame = false;
             ShowMapFrame = false;
 
-            _stateKnown = App.ReadingContext.ThisParticipant.RegistrationInfo.StateKnown;
+            _stateKnown = IndividualParticipant.ProfileData.RegistrationInfo.StateKnown;
             
             // set the pickers to update their content lists here if state was already indicated elsewhere in the application
             if(_stateKnown) 
             {
-                SelectedStateEnum = App.ReadingContext.ThisParticipant.RegistrationInfo.SelectedStateAsEnum;
+                SelectedStateEnum = IndividualParticipant.ProfileData.RegistrationInfo.SelectedStateAsEnum;
                 
                 // set the state index pickers
                 SelectedStateAsInt = (int)SelectedStateEnum;
                 
                 var choosableStateElectorate = (SelectedStateEnum == ParliamentData.StateEnum.TAS )
-                   ? App.ReadingContext.ThisParticipant.StateUpperHouseElectorate
-                   : App.ReadingContext.ThisParticipant.StateLowerHouseElectorate;
+                   ? IndividualParticipant.ProfileData.StateUpperHouseElectorate
+                   : IndividualParticipant.ProfileData.StateLowerHouseElectorate;
                 UpdateElectorateInferencesFromStateAndCommElectorate(SelectedStateEnum,
                     choosableStateElectorate,
-                    App.ReadingContext.ThisParticipant.CommonwealthElectorate);
+                    IndividualParticipant.ProfileData.CommonwealthElectorate);
             }
 
-            if (!string.IsNullOrEmpty(App.ReadingContext.ThisParticipant.CommonwealthElectorate))
+            if (!string.IsNullOrEmpty(IndividualParticipant.ProfileData.CommonwealthElectorate))
             {
                 ShowMapFrame = true;
-                var electorateString = ParliamentData.ConvertGeoscapeElectorateToStandard(App.ReadingContext.ThisParticipant.RegistrationInfo.State, App.ReadingContext.ThisParticipant.CommonwealthElectorate);
+                var electorateString = ParliamentData.ConvertGeoscapeElectorateToStandard(IndividualParticipant.ProfileData.RegistrationInfo.State, IndividualParticipant.ProfileData.CommonwealthElectorate);
                 ShowMapOfElectorate(electorateString);
             }
 
@@ -311,7 +311,7 @@ namespace RightToAskClient.ViewModels
                 IsBusy = true; // no longer displaying the activity indicator since the webview shows that it is being updated
                 Result<GeoscapeAddressFeature>? httpResponse;
 
-                var state = App.ReadingContext.ThisParticipant.RegistrationInfo.State;
+                var state = IndividualParticipant.ProfileData.RegistrationInfo.State;
 
                 if (string.IsNullOrEmpty(state))
                 {
@@ -353,8 +353,8 @@ namespace RightToAskClient.ViewModels
                         ReportLabelText = "";
 
                         var electoratePopupTitle = "Electorates Found!";
-                        var electoratePopupText = "Federal electorate: " + App.ReadingContext.ThisParticipant.CommonwealthElectorate +
-                                                  "\n" + "State lower house electorate: " + App.ReadingContext.ThisParticipant.StateLowerHouseElectorate;
+                        var electoratePopupText = "Federal electorate: " + IndividualParticipant.ProfileData.CommonwealthElectorate +
+                                                  "\n" + "State lower house electorate: " + IndividualParticipant.ProfileData.StateLowerHouseElectorate;
                         var electoratesFoundPopup = new OneButtonPopup(electoratePopupTitle, electoratePopupText, AppResources.OKText);
                         _ = await Application.Current.MainPage.Navigation.ShowPopupAsync(electoratesFoundPopup);
 
@@ -368,12 +368,12 @@ namespace RightToAskClient.ViewModels
                     }
                     ShowSkipButton = false;
                     // display the map if we stored the Federal Electorate properly
-                    if (!string.IsNullOrEmpty(App.ReadingContext.ThisParticipant.CommonwealthElectorate))
+                    if (!string.IsNullOrEmpty(IndividualParticipant.ProfileData.CommonwealthElectorate))
                     {
                         ShowMapFrame = true;
                         ShowKnowElectoratesFrame = false;
                         ShowAddressStack = false;
-                        var electorateString = ParliamentData.ConvertGeoscapeElectorateToStandard(state, App.ReadingContext.ThisParticipant.CommonwealthElectorate);
+                        var electorateString = ParliamentData.ConvertGeoscapeElectorateToStandard(state, IndividualParticipant.ProfileData.CommonwealthElectorate);
                         ShowMapOfElectorate(electorateString);
                     }
                 }
@@ -387,9 +387,9 @@ namespace RightToAskClient.ViewModels
 
         private void AddElectorates(GeoscapeAddressFeature addressData)
         {
-            var state = App.ReadingContext.ThisParticipant.RegistrationInfo.SelectedStateAsEnum;
+            var state = IndividualParticipant.ProfileData.RegistrationInfo.SelectedStateAsEnum;
             var electorates = ParliamentData.GetElectoratesFromGeoscapeAddress(state, addressData);
-            App.ReadingContext.ThisParticipant.RegistrationInfo.Electorates = electorates;
+            IndividualParticipant.ProfileData.RegistrationInfo.Electorates = electorates;
             
             // There really shouldn't be any scenario in which there aren't any electorates here, unless something goes
             // wrong extracting Electorate strings from the Geoscape address.
@@ -417,13 +417,13 @@ namespace RightToAskClient.ViewModels
                 && !string.IsNullOrEmpty(AllStateChoosableElectorates[SelectedStateElectorateIndex]))
             {
                 var chosenElectorate = AllStateChoosableElectorates[SelectedStateElectorateIndex];
-                var state = App.ReadingContext.ThisParticipant.RegistrationInfo.SelectedStateAsEnum;
-                App.ReadingContext.ThisParticipant.RegistrationInfo.Electorates
+                var state = IndividualParticipant.ProfileData.RegistrationInfo.SelectedStateAsEnum;
+                IndividualParticipant.ProfileData.RegistrationInfo.Electorates
                     = ParliamentData.FindAllRelevantElectorates(state,
-                        chosenElectorate, App.ReadingContext.ThisParticipant.CommonwealthElectorate);
+                        chosenElectorate, IndividualParticipant.ProfileData.CommonwealthElectorate);
                 (_, _, StateInferredElectorate) 
                     = ParliamentData.InferOtherChamberInfoGivenOneRegion(SelectedStateEnum, chosenElectorate, 
-                        App.ReadingContext.ThisParticipant.CommonwealthElectorate);
+                        IndividualParticipant.ProfileData.CommonwealthElectorate);
             }
             RevealNextStepAndCommunicateIfElectoratesKnown();
         }
@@ -440,7 +440,7 @@ namespace RightToAskClient.ViewModels
                 
                 // TODO Consider whether electorates should be readonly and instead have a function that updates them
                 // given this info.
-                App.ReadingContext.ThisParticipant.RegistrationInfo.Electorates
+                IndividualParticipant.ProfileData.RegistrationInfo.Electorates
                         = ParliamentData.FindAllRelevantElectorates(SelectedStateEnum, "", FederalElectorates[SelectedFederalElectorate]);
                 // For Tasmania, we need your federal electorate to infer your state Legislative Assembly electorate.
                 if (SelectedStateEnum == ParliamentData.StateEnum.TAS)
@@ -462,7 +462,7 @@ namespace RightToAskClient.ViewModels
 
         private void CommunicateElectoratesKnown()
         {
-            App.ReadingContext.ThisParticipant.ElectoratesKnown = true;
+            IndividualParticipant.ElectoratesKnown = true;
             Preferences.Set(Constants.ElectoratesKnown, true);
             MessagingCenter.Send(this, Constants.ElectoratesKnown);
         }
@@ -493,7 +493,7 @@ namespace RightToAskClient.ViewModels
 
         private void OnStatePickerSelectedIndexChanged()
         {
-            (_stateKnown, SelectedStateEnum) = App.ReadingContext.ThisParticipant.RegistrationInfo.UpdateStateStorePreferences(SelectedStateAsInt);
+            (_stateKnown, SelectedStateEnum) = IndividualParticipant.ProfileData.RegistrationInfo.UpdateStateStorePreferences(SelectedStateAsInt);
                 
                 if (_stateKnown)
                 {

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/MPRegistrationVerificationViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/MPRegistrationVerificationViewModel.cs
@@ -140,16 +140,16 @@ namespace RightToAskClient.ViewModels
             Preferences.Set(Constants.IsVerifiedMPAccount, true);
             Preferences.Set(Constants.IsVerifiedMPStafferAccount, _isStaffer); 
             Preferences.Set(Constants.MPRegisteredAs,JsonSerializer.Serialize(MPRepresenting));
-            var registrationObjectToSave = new ServerUser(App.ReadingContext.ThisParticipant.RegistrationInfo);
+            var registrationObjectToSave = new ServerUser(IndividualParticipant.ProfileData.RegistrationInfo);
             Preferences.Set(Constants.RegistrationInfo, JsonSerializer.Serialize(registrationObjectToSave));
         }
 
         private void StoreMPRegistration()
         {
-            App.ReadingContext.ThisParticipant.IsVerifiedMPAccount = true;
-            App.ReadingContext.ThisParticipant.MPRegisteredAs = MPRepresenting;
-            App.ReadingContext.ThisParticipant.IsVerifiedMPStafferAccount = _isStaffer;
-            App.ReadingContext.ThisParticipant.RegistrationInfo.Badges.Add(
+            IndividualParticipant.IsVerifiedMPAccount = true;
+            IndividualParticipant.MPRegisteredAs = MPRepresenting;
+            IndividualParticipant.IsVerifiedMPStafferAccount = _isStaffer;
+            IndividualParticipant.ProfileData.RegistrationInfo.Badges.Add(
                     new Badge()
                     {
                         badge = IsStaffer ? BadgeType.MPStaff : BadgeType.MP,

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
@@ -134,7 +134,7 @@ namespace RightToAskClient.ViewModels
         {
             get
             {
-                var thisUser =  App.ReadingContext.ThisParticipant.RegistrationInfo.uid;
+                var thisUser =  IndividualParticipant.ProfileData.RegistrationInfo.uid;
                 var questionWriter = _question.QuestionSuggester;
                 return IsNewQuestion || 
                        (!string.IsNullOrEmpty(thisUser) && !string.IsNullOrEmpty(questionWriter) && thisUser == questionWriter);
@@ -232,7 +232,7 @@ namespace RightToAskClient.ViewModels
             // set up empty question
             Question = new Question();
             ReportLabelText = "";
-            Question.QuestionSuggester = App.ReadingContext.ThisParticipant.RegistrationInfo.uid;
+            Question.QuestionSuggester = IndividualParticipant.ProfileData.RegistrationInfo.uid;
 
             // set defaults
             IsNewQuestion = false;
@@ -294,11 +294,11 @@ namespace RightToAskClient.ViewModels
             UpvoteCommand = new AsyncCommand(async () =>
             {
                 await NavigationUtils.DoRegistrationCheck(Instance);
-                if (App.ReadingContext.ThisParticipant.IsRegistered)
+                if (IndividualParticipant.IsRegistered)
                 {
                     // upvoting a question will add it to their list
                     // TODO We probably want to separate having _written_ questions from having upvoted them.
-                    App.ReadingContext.ThisParticipant.HasQuestions = true;
+                    IndividualParticipant.HasQuestions = true;
                     Preferences.Set(Constants.HasQuestions, true);
                     
                     if (Question.AlreadyUpvoted)
@@ -411,7 +411,7 @@ namespace RightToAskClient.ViewModels
             // set defaults
             Question = new Question();
             ReportLabelText = "";
-            Question.QuestionSuggester = App.ReadingContext.ThisParticipant.RegistrationInfo.uid;
+            Question.QuestionSuggester = IndividualParticipant.ProfileData.RegistrationInfo.uid;
         }
 
         public void ReinitQuestionUpdates()
@@ -502,10 +502,10 @@ namespace RightToAskClient.ViewModels
             // TODO This should not be necessary any more. Perhaps turn into a debug assertion?
             await NavigationUtils.DoRegistrationCheck(Instance);
             
-            if (App.ReadingContext.ThisParticipant.IsRegistered)
+            if (IndividualParticipant.IsRegistered)
             {
                 // This isn't necessary unless the person has just registered, but is necessary if they have.
-                Instance.Question.QuestionSuggester = App.ReadingContext.ThisParticipant.RegistrationInfo.uid;
+                Instance.Question.QuestionSuggester = IndividualParticipant.ProfileData.RegistrationInfo.uid;
                 var validQuestion = Question.ValidateNewQuestion();
                 if (validQuestion)
                 {
@@ -523,7 +523,7 @@ namespace RightToAskClient.ViewModels
         {
             await NavigationUtils.DoRegistrationCheck(Instance);
 
-            if (App.ReadingContext.ThisParticipant.IsRegistered)
+            if (IndividualParticipant.IsRegistered)
             {
                 var validQuestion = Question.ValidateUpdateQuestion();
                 if (validQuestion) 
@@ -540,7 +540,7 @@ namespace RightToAskClient.ViewModels
         private async Task<bool> SendNewQuestionToServer()
         {
             // This isn't supposed to be called for unregistered participants.
-            if (!App.ReadingContext.ThisParticipant.IsRegistered) return false;
+            if (!IndividualParticipant.IsRegistered) return false;
 
             // TODO use returnedData to record questionID, version, hash
             (bool isValid, string errorMessage, string returnedData) successfulSubmission =
@@ -561,7 +561,7 @@ namespace RightToAskClient.ViewModels
         private async void PromptForNextStepAndClearQuestionIfNeeded() 
         { 
             // creating a question will add it to their list
-            App.ReadingContext.ThisParticipant.HasQuestions = true;
+            IndividualParticipant.HasQuestions = true;
             Preferences.Set(Constants.HasQuestions, true);
 
             //FIXME update version, just like for edits.
@@ -593,7 +593,7 @@ namespace RightToAskClient.ViewModels
         private async void SendQuestionEditToServer()
         {
             // This isn't supposed to be called for unregistered participants.
-            if (!App.ReadingContext.ThisParticipant.IsRegistered) return;
+            if (!IndividualParticipant.IsRegistered) return;
             
             var successfulSubmission = await BuildSignAndUploadQuestionUpdates();
             

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
@@ -78,31 +78,6 @@ namespace RightToAskClient.ViewModels
             set => SetProperty(ref _isNewQuestion, value);
         }
 
-        // TODO What does this mean??
-        private bool _isReadingOnly;
-        public bool IsReadingOnly
-        {
-            get => _isReadingOnly;
-            set => SetProperty(ref _isReadingOnly, value);
-        }
-
-        // Whether the 'Option B' path, in which you choose both someone to answer 
-        // and someone to raise the question, has been selected. This is the opposite of
-        // 'AnswerInApp.' Default to true unless the user explicitly chooses to get an answer
-        // in the app.
-        /*
-        private bool _raisedByOptionSelected = true;
-        public bool RaisedByOptionSelected
-        {
-            get => _raisedByOptionSelected;
-            set
-            {
-                SetProperty(ref _raisedByOptionSelected, value);
-                AnswerInApp = !_raisedByOptionSelected;
-            }
-        }
-        */
-
         private HowAnsweredOptions _howAnswered = HowAnsweredOptions.DontKnow; 
 
         public HowAnsweredOptions HowAnswered
@@ -236,7 +211,6 @@ namespace RightToAskClient.ViewModels
 
             // set defaults
             IsNewQuestion = false;
-            IsReadingOnly = App.ReadingContext.IsReadingOnly; // crashes here if setting up existing test questions
             HowAnswered = HowAnsweredOptions.DontKnow;
             AnotherUserButtonText = AppResources.AnotherUserButtonText;
             NotSureWhoShouldRaiseButtonText = AppResources.NotSureButtonText;

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
@@ -235,7 +235,7 @@ namespace RightToAskClient.ViewModels
                 // Question.AnswerInApp = false;
                 // AnswerInApp = false;
                 var pageToSearchAuthorities
-                    = new SelectableListPage(App.ReadingContext.Filters.AuthorityLists, "Choose authorities");
+                    = new SelectableListPage(App.GlobalFilterChoices.AuthorityLists, "Choose authorities");
                 await Shell.Current.Navigation.PushAsync(pageToSearchAuthorities).ContinueWith((_) => 
                 {
                     MessagingCenter.Send(this, Constants.GoToAskingPageNext); // Sends this view model
@@ -544,7 +544,7 @@ namespace RightToAskClient.ViewModels
             _ = await Application.Current.MainPage.Navigation.ShowPopupAsync(popup);
             if (GoHome)
             {
-                App.ReadingContext.Filters.RemoveAllSelections();
+                App.GlobalFilterChoices.RemoveAllSelections();
                 MessagingCenter.Send(this, Constants.QuestionSubmittedDeleteDraft);
                 await Application.Current.MainPage.Navigation.PopToRootAsync();
                     

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
@@ -80,10 +80,10 @@ namespace RightToAskClient.ViewModels
 
         public string Keyword
         {
-            get => App.ReadingContext.Filters.SearchKeyword;
+            get => App.GlobalFilterChoices.SearchKeyword;
             set
             {
-                App.ReadingContext.Filters.SearchKeyword = value;
+                App.GlobalFilterChoices.SearchKeyword = value;
                 OnPropertyChanged();
             }
         }
@@ -94,7 +94,7 @@ namespace RightToAskClient.ViewModels
         // constructor
         public ReadingPageViewModel()
         {
-            Keyword = App.ReadingContext.Filters.SearchKeyword;
+            Keyword = App.GlobalFilterChoices.SearchKeyword;
             
             // If we're already searching for something, show the user what.
             ShowSearchFrame = !string.IsNullOrWhiteSpace(Keyword); 
@@ -206,7 +206,7 @@ namespace RightToAskClient.ViewModels
             });
             MessagingCenter.Subscribe<SelectableListViewModel>(this,"ReadQuestionsWithASingleQuestionWriter", (sender) =>
             {
-                var questionWriter = App.ReadingContext.Filters.QuestionWriterLists.SelectedEntities.FirstOrDefault();
+                var questionWriter = App.GlobalFilterChoices.QuestionWriterLists.SelectedEntities.FirstOrDefault();
                 if (questionWriter is null)
                 {
                     Debug.WriteLine("Error: ReadingPage for single question writer but no selection.");
@@ -246,7 +246,7 @@ namespace RightToAskClient.ViewModels
                 QuestionSuggester = (IndividualParticipant.IsRegistered)
                     ? IndividualParticipant.ProfileData.RegistrationInfo.uid
                     : "",
-                Filters = App.ReadingContext.Filters,
+                Filters = App.GlobalFilterChoices,
                 DownVotes = 0,
                 UpVotes = 0
             };
@@ -357,7 +357,7 @@ namespace RightToAskClient.ViewModels
         // given user.
         private async Task<Result<List<string>>> GetAppropriateQuestionList()
         {
-            var filters = App.ReadingContext.Filters;
+            var filters = App.GlobalFilterChoices;
             // If we're looking for all the questions written by a given user, just request them.
             if (_readByQuestionWriter && !string.IsNullOrWhiteSpace(_writerOnlyUid))
             {

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
@@ -35,21 +35,6 @@ namespace RightToAskClient.ViewModels
             set => SetProperty(ref _showSearchFrame, value);
         }
 
-        private bool _dontShowFirstTimeReadingPopup;
-        public bool DontShowFirstTimeReadingPopup
-        {
-            get => _dontShowFirstTimeReadingPopup;
-            set
-            {
-                var changed = SetProperty(ref _dontShowFirstTimeReadingPopup, value);
-                if (changed)
-                {
-                    Preferences.Set(Constants.DontShowFirstTimeReadingPopup, value);
-                    App.ReadingContext.DontShowFirstTimeReadingPopup = value;
-                }
-            }
-        }
-
         private string _heading1 = string.Empty;
         public string Heading1
         {
@@ -139,12 +124,13 @@ namespace RightToAskClient.ViewModels
             PopupLabelText = AppResources.ReadingPageHeader1;
             PopupHeaderText = Heading1;
             
-            if (!App.ReadingContext.DontShowFirstTimeReadingPopup)
+            var showFirstTimeReadingPopup = Preferences.Get(Constants.ShowFirstTimeReadingPopup, true);
+            if (showFirstTimeReadingPopup)
             {
                 InfoPopupCommand.ExecuteAsync();
                 
                 // Only show it once.
-                DontShowFirstTimeReadingPopup = true;
+                Preferences.Set(Constants.ShowFirstTimeReadingPopup, false);
             }
             
             KeepQuestionButtonCommand = new AsyncCommand(async () =>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
@@ -175,7 +175,7 @@ namespace RightToAskClient.ViewModels
             {
                 await NavigationUtils.DoRegistrationCheck(this);
 
-                if (App.ReadingContext.ThisParticipant.IsRegistered)
+                if (IndividualParticipant.IsRegistered)
                 {
                     ShowQuestionFrame = true;
                 }
@@ -191,9 +191,9 @@ namespace RightToAskClient.ViewModels
             RemoveQuestionCommand = new Command<Question>(questionToRemove =>
             {
                 // store question ID for later data manipulation?
-                if (!App.ReadingContext.ThisParticipant.RemovedQuestionIDs.Contains(questionToRemove.QuestionId))
+                if (!IndividualParticipant.RemovedQuestionIDs.Contains(questionToRemove.QuestionId))
                 {
-                    App.ReadingContext.ThisParticipant.RemovedQuestionIDs.Add(questionToRemove.QuestionId);
+                    IndividualParticipant.RemovedQuestionIDs.Add(questionToRemove.QuestionId);
                 }
                 QuestionsToDisplay.Remove(questionToRemove);
             });
@@ -239,15 +239,13 @@ namespace RightToAskClient.ViewModels
         // helper methods
         private async void OnSaveButtonClicked()
         {
-            var thisParticipant = App.ReadingContext.ThisParticipant;
-
             // Set up new question in preparation for upload. 
             // The filters are what the user has chosen through the flow.
             var newQuestion = new Question
             {
                 QuestionText = DraftQuestion,
-                QuestionSuggester = (thisParticipant.IsRegistered)
-                    ? thisParticipant.RegistrationInfo.uid
+                QuestionSuggester = (IndividualParticipant.IsRegistered)
+                    ? IndividualParticipant.ProfileData.RegistrationInfo.uid
                     : "",
                 Filters = App.ReadingContext.Filters,
                 DownVotes = 0,
@@ -322,10 +320,10 @@ namespace RightToAskClient.ViewModels
 
 
             // after getting the list of questions, remove the ids for dismissed questions, and set the upvoted status of liked ones
-            for (var i = 0; i < App.ReadingContext.ThisParticipant.RemovedQuestionIDs.Count; i++)
+            for (var i = 0; i < IndividualParticipant.RemovedQuestionIDs.Count; i++)
             {
                 var temp = questionsToDisplay
-                    .FirstOrDefault(q => q.QuestionId == App.ReadingContext.ThisParticipant.RemovedQuestionIDs[i]);
+                    .FirstOrDefault(q => q.QuestionId == IndividualParticipant.RemovedQuestionIDs[i]);
                 if (temp != null)
                 {
                     questionsToDisplay.Remove(temp);
@@ -335,9 +333,7 @@ namespace RightToAskClient.ViewModels
             // set previously upvoted questions
             foreach (var q in questionsToDisplay)
             {
-                foreach (var qId in App
-                             .ReadingContext
-                             .ThisParticipant
+                foreach (var qId in IndividualParticipant
                              .UpvotedQuestionIDs
                              .Where(qId => q.QuestionId == qId))
                 {
@@ -345,9 +341,7 @@ namespace RightToAskClient.ViewModels
                 }
 
                 // set previously flagged/reported questions
-                foreach (var qID in App
-                             .ReadingContext
-                             .ThisParticipant
+                foreach (var qID in IndividualParticipant 
                              .ReportedQuestionIDs
                              .Where(qId => q.QuestionId == qId))
                 {

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
@@ -159,10 +159,23 @@ namespace RightToAskClient.ViewModels
             });
             DraftCommand = new AsyncCommand(async () =>
             {
+                // Check that they are registered - if not, prompt them to get an account.
                 await NavigationUtils.DoRegistrationCheck(this);
 
                 if (IndividualParticipant.IsRegistered)
                 {
+                    // If this is their first question, show them the 5-step instructions.
+                    var showHowToPublishPopup = Preferences.Get(Constants.ShowHowToPublishPopup, true);
+                    if (showHowToPublishPopup)
+                    {
+                        var popup = new HowToPublishPopup();
+                        if (popup != null) _ = await Application.Current.MainPage.Navigation.ShowPopupAsync(popup);
+
+                        // Only show it once.
+                        Preferences.Set(Constants.ShowHowToPublishPopup, false);
+                    }
+                    
+                    // Now let them start drafting.
                     ShowQuestionFrame = true;
                 }
             });

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/RegistrationViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/RegistrationViewModel.cs
@@ -87,7 +87,7 @@ namespace RightToAskClient.ViewModels
             {
                 _selectedStateAsIndex = value;
                 ParliamentData.StateEnum selectedState;
-                (_stateKnown, selectedState) =  App.ReadingContext.ThisParticipant.RegistrationInfo.UpdateStateStorePreferences(SelectedStateAsIndex);
+                (_stateKnown, selectedState) =  IndividualParticipant.ProfileData.RegistrationInfo.UpdateStateStorePreferences(SelectedStateAsIndex);
                 
                 // Include new state in updates. At the moment, this means that there is no way that
                 // someone who has previously selected a state can
@@ -269,20 +269,18 @@ namespace RightToAskClient.ViewModels
         public RegistrationViewModel() : this(false)
         {
             // initialize defaults
-            var me = App.ReadingContext.ThisParticipant;
-            Title = me.IsRegistered ? AppResources.EditYourAccountTitle : AppResources.CreateAccountTitle;
-            // Title = App.ReadingContext.ThisParticipant.IsRegistered ? AppResources.EditYourAccountTitle : AppResources.CreateAccountTitle;
+            Title = IndividualParticipant.IsRegistered ? AppResources.EditYourAccountTitle : AppResources.CreateAccountTitle;
             ReportLabelText = "";
-            _registration = me.RegistrationInfo; 
+            _registration = IndividualParticipant.ProfileData.RegistrationInfo; 
             
             ShowTheRightButtonsForOwnAccount();
-            CanEditUid = !me.IsRegistered;
+            CanEditUid = !IndividualParticipant.IsRegistered;
 
             // uid should still be sent in the 'update' even though it doesn't change.
             _registrationUpdates.uid = _registration.uid;
             _oldElectorates = _registration.Electorates;
 
-            PopupLabelText = App.ReadingContext.ThisParticipant.IsRegistered ? AppResources.EditAccountPopupText : AppResources.CreateNewAccountPopupText;
+            PopupLabelText = IndividualParticipant.IsRegistered ? AppResources.EditAccountPopupText : AppResources.CreateNewAccountPopupText;
                 
             _selectableMPList = new SelectableList<MP>(ParliamentData.AllMPs, new List<MP>());
 
@@ -366,21 +364,20 @@ namespace RightToAskClient.ViewModels
 
         public void ShowTheRightButtonsForOwnAccount()
         {
-            var me = App.ReadingContext.ThisParticipant;
-            ShowUpdateAccountButton = me.IsRegistered;
-            ShowRegisterMPButton = me.IsRegistered;
-            ShowExistingMPRegistrationLabel = me.IsVerifiedMPAccount || me.IsVerifiedMPStafferAccount;
-            ShowStafferLabel = me.IsVerifiedMPStafferAccount;
+            ShowUpdateAccountButton = IndividualParticipant.IsRegistered;
+            ShowRegisterMPButton = IndividualParticipant.IsRegistered;
+            ShowExistingMPRegistrationLabel = IndividualParticipant.IsVerifiedMPAccount || IndividualParticipant.IsVerifiedMPStafferAccount;
+            ShowStafferLabel = IndividualParticipant.IsVerifiedMPStafferAccount;
             ShowDMButton = false;
             ShowSeeQuestionsButton = false;
             ShowFollowButton = false;
 
-            if (!App.ReadingContext.ThisParticipant.ElectoratesKnown)
+            if (!IndividualParticipant.ElectoratesKnown)
             {
                 RegisterCitizenButtonText = "Next: Find your electorates";
             }
 
-            if (!App.ReadingContext.ThisParticipant.IsRegistered)
+            if (!IndividualParticipant.IsRegistered)
             {
                 ShowRegisterCitizenButton = true;
                 ShowRegisterOrgButton = true;
@@ -397,14 +394,14 @@ namespace RightToAskClient.ViewModels
         private async void OnSaveButtonClicked()
         {
             SaveRegistrationToPreferences(_registration);
-            Debug.Assert(!App.ReadingContext.ThisParticipant.IsRegistered);
+            Debug.Assert(!IndividualParticipant.IsRegistered);
 
             _registration.public_key = ClientSignatureGenerationService.MyPublicKey; 
             var regTest = _registration.IsValid().Err;
             if (string.IsNullOrEmpty(regTest))
             {
                 // see if we need to push the electorates page or if we push the server account things
-                if (!App.ReadingContext.ThisParticipant.ElectoratesKnown)
+                if (!IndividualParticipant.ElectoratesKnown)
                 {
                     // if MPs have not been found for this user yet, prompt to find them
                     var popup = new TwoButtonPopup(this, AppResources.MPsPopupTitle, AppResources.MPsPopupText, AppResources.SkipButtonText, AppResources.YesButtonText);
@@ -476,7 +473,7 @@ namespace RightToAskClient.ViewModels
         private async void SendUpdatedUserToServer()
         {
             // Shouldn't be updating a non-existent user. 
-            Debug.Assert(App.ReadingContext.ThisParticipant.IsRegistered);
+            Debug.Assert(IndividualParticipant.IsRegistered);
 
             var hasChanges = false;
             if (_registrationUpdates.uid == null)
@@ -540,10 +537,10 @@ namespace RightToAskClient.ViewModels
 
         private void UpdateLocalRegistrationInfo()
         {
-            App.ReadingContext.ThisParticipant.RegistrationInfo = _registration;
-            App.ReadingContext.ThisParticipant.IsRegistered = true;
+            IndividualParticipant.ProfileData.RegistrationInfo = _registration;
+            IndividualParticipant.IsRegistered = true;
             // save the registration to preferences
-            Preferences.Set(Constants.IsRegistered, App.ReadingContext.ThisParticipant.IsRegistered); 
+            Preferences.Set(Constants.IsRegistered, IndividualParticipant.IsRegistered); 
         }
 
 

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/RegistrationViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/RegistrationViewModel.cs
@@ -397,8 +397,10 @@ namespace RightToAskClient.ViewModels
             Debug.Assert(!IndividualParticipant.IsRegistered);
 
             _registration.public_key = ClientSignatureGenerationService.MyPublicKey; 
-            var regTest = _registration.IsValid().Err;
-            if (string.IsNullOrEmpty(regTest))
+            
+            // Check that the registration info we're about to send to the server is valid.
+            var regTest = _registration.IsValid();
+            if (regTest.Success)
             {
                 // see if we need to push the electorates page or if we push the server account things
                 if (!IndividualParticipant.ElectoratesKnown)
@@ -420,12 +422,15 @@ namespace RightToAskClient.ViewModels
                     await SendNewUserToServer();
                 }
             }
+            // If registration info is invalid, prompt the user to fix it up.
             else
             {
-                if (regTest != null)
+                var errorMessage = "Invalid registration.";
+                if (regTest is ErrorResult errorResult)
                 {
-                    PromptUser(regTest);
+                    errorMessage = errorResult.Message;
                 }
+                PromptUser(errorMessage);
             }
         }
 

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/RegistrationViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/RegistrationViewModel.cs
@@ -425,7 +425,7 @@ namespace RightToAskClient.ViewModels
             // If registration info is invalid, prompt the user to fix it up.
             else
             {
-                var errorMessage = "Invalid registration.";
+                var errorMessage = AppResources.InvalidRegistration;
                 if (regTest is ErrorResult errorResult)
                 {
                     errorMessage = errorResult.Message;

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/HowToPublishPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/HowToPublishPopup.xaml
@@ -4,7 +4,7 @@
            xmlns:views="clr-namespace:RightToAskClient.Views"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="RightToAskClient.Views.Popups.HowToPublishPopup"
-           Size="350,500"
+           Size="350,600"
            IsLightDismissEnabled="True"
            Color="Transparent">
     <Frame CornerRadius="10" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" Margin="0" Padding="0"

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/ReadingPagePopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/ReadingPagePopup.xaml
@@ -24,11 +24,6 @@
                     <Button Text="{xct:Translate OKText}" Grid.Column="1" Clicked="Button_Clicked" 
                             Style="{StaticResource PopupOKButton}" />
                 </Grid>
-                <!--
-                <StackLayout Orientation="Horizontal" Margin="0,0,0,0">
-                    <Label Text="Don't show this again: " VerticalOptions="Center" />
-                    <CheckBox IsChecked="{Binding DontShowFirstTimeReadingPopup}" />
-                </StackLayout>  -->
             </StackLayout>
         </StackLayout>
     </ScrollView>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using RightToAskClient.Models;
 using RightToAskClient.ViewModels;
 using Xamarin.Forms;
 using RightToAskClient.Resx;
@@ -74,7 +75,7 @@ namespace RightToAskClient.Views
             BackgroundLabel.IsVisible = BackgroundEditor.IsVisible;
 
             // Only MPs can answer questions.
-            var isMP = App.ReadingContext.ThisParticipant.IsVerifiedMPAccount;
+            var isMP = IndividualParticipant.IsVerifiedMPAccount;
             AnswerEditor.Style = isMP ? normalEditorStyle : disabledEditorStyle;
             AnswerEditor.IsEnabled = isMP;
         }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/RegisterAccountPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/RegisterAccountPage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using RightToAskClient.Models;
 using RightToAskClient.ViewModels;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -24,15 +25,15 @@ namespace RightToAskClient.Views
             if (picker.SelectedIndex != -1)
             {
                 string state = (string)picker.SelectedItem;
-                App.ReadingContext.ThisParticipant.RegistrationInfo.SelectedStateAsIndex = picker.SelectedIndex;
-                App.ReadingContext.ThisParticipant.UpdateChambers(state);
+                IndividualParticipant.ProfileData.RegistrationInfo.SelectedStateAsIndex = picker.SelectedIndex;
+                IndividualParticipant.UpdateChambers(state);
             }
         }
         */
 
         private void OnRegisterEmailFieldCompleted(object sender, EventArgs e)
         {
-            App.ReadingContext.ThisParticipant.UserEmail = ((Editor)sender).Text;
+            IndividualParticipant.ProfileData.UserEmail = ((Editor)sender).Text;
         }
     }
 }

--- a/RightToAskClient/UnitTests/FilterViewModelTests.cs
+++ b/RightToAskClient/UnitTests/FilterViewModelTests.cs
@@ -22,7 +22,7 @@ namespace UnitTests
             FilterViewModel vm = new FilterViewModel();
             FilterChoices filters = vTests.ValidateFiltersTest();
             filters.SearchKeyword = "changed Keyword";
-            App.ReadingContext.Filters.SearchKeyword = filters.SearchKeyword;
+            App.GlobalFilterChoices.SearchKeyword = filters.SearchKeyword;
 
             // act
             vm.ReinitData(); // this should set vm.Keyword

--- a/RightToAskClient/UnitTests/FindMPsViewModelTests.cs
+++ b/RightToAskClient/UnitTests/FindMPsViewModelTests.cs
@@ -31,16 +31,16 @@ namespace UnitTests
 
             // act on the data
             registrationInfo = vTests.ValidRegistrationTest();
-            App.ReadingContext.ThisParticipant.RegistrationInfo = registrationInfo;
+            IndividualParticipant.ProfileData.RegistrationInfo = registrationInfo;
             address = vTests.TestValidAddress();
-            App.ReadingContext.ThisParticipant.Address = address;
+            IndividualParticipant.ProfileData.Address = address;
             vm.Address = address;
             bool validReg = registrationInfo.Validate();
             button.Command.Execute(null);
 
             // assert
             Assert.True(validReg);
-            Assert.True(!string.IsNullOrEmpty(App.ReadingContext.ThisParticipant.RegistrationInfo.State));
+            Assert.True(!string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.State));
             Assert.True(string.IsNullOrEmpty(vm.ReportLabelText));
             Assert.True(vm.ShowFindMPsButton);
             Assert.False(vm.ShowSkipButton);

--- a/RightToAskClient/UnitTests/QuestionViewModelTests.cs
+++ b/RightToAskClient/UnitTests/QuestionViewModelTests.cs
@@ -77,7 +77,7 @@ namespace UnitTests
         public void EditQuestionCommandTest()
         {
             // arrange
-            App.ReadingContext.ThisParticipant.IsRegistered = false;
+            IndividualParticipant.IsRegistered = false;
             Button button = new Button()
             {
                 Command = vm.EditAnswerCommand
@@ -250,7 +250,7 @@ namespace UnitTests
         public void UpvoteCommandTest()
         {
             // arrange
-            App.ReadingContext.ThisParticipant.IsRegistered = true;
+            IndividualParticipant.IsRegistered = true;
             vm.Question.UpVotes = 0;
             vm.Question.AlreadyUpvoted = false;
             Button button = new Button
@@ -268,7 +268,7 @@ namespace UnitTests
         public void UndoUpvoteCommandTest()
         {
             // arrange
-            App.ReadingContext.ThisParticipant.IsRegistered = true;
+            IndividualParticipant.IsRegistered = true;
             vm.Question.UpVotes = 1;
             vm.Question.AlreadyUpvoted = true;
             Button button = new Button
@@ -328,10 +328,8 @@ namespace UnitTests
         public void SaveQuestionCommandTest()
         {
             // arrange
-            IndividualParticipant testUser = new IndividualParticipant();
-            testUser.RegistrationInfo = ValidRegistrationWithValidElectorate;
-            App.ReadingContext.ThisParticipant = testUser;
-            App.ReadingContext.ThisParticipant.IsRegistered = true;
+            IndividualParticipant.ProfileData.RegistrationInfo = ValidRegistrationWithValidElectorate;
+            IndividualParticipant.IsRegistered = true;
             vm.Question = TestQuestion;
             //var questionDetailPage = new QuestionDetailPage();
             Button button = new Button

--- a/RightToAskClient/UnitTests/QuestionViewModelTests.cs
+++ b/RightToAskClient/UnitTests/QuestionViewModelTests.cs
@@ -47,7 +47,7 @@ namespace UnitTests
 
             // act
             button.Command.Execute(null);
-            string result = String.Join(" ", App.ReadingContext.Filters.SelectedAuthorities) + " is appearing at Senate Estimates tomorrow";
+            string result = String.Join(" ", App.GlobalFilterChoices.SelectedAuthorities) + " is appearing at Senate Estimates tomorrow";
 
             // assert
             Assert.Equal(result, vm.SenateEstimatesAppearanceText);

--- a/RightToAskClient/UnitTests/ReadingPageViewModelTests.cs
+++ b/RightToAskClient/UnitTests/ReadingPageViewModelTests.cs
@@ -21,7 +21,7 @@ namespace UnitTests
         public void ReadingPageConstructorTest()
         {
             // arrange
-            App.ReadingContext.Filters.SearchKeyword = "Test";
+            App.GlobalFilterChoices.SearchKeyword = "Test";
             App.ReadingContext.DraftQuestion = "FakeDraftQuestion";
 
             // act
@@ -41,7 +41,7 @@ namespace UnitTests
         public void ReadingPageConstructorReadingOnlyTest()
         {
             // arrange
-            App.ReadingContext.Filters.SearchKeyword = "Test";
+            App.GlobalFilterChoices.SearchKeyword = "Test";
             App.ReadingContext.DraftQuestion = "FakeDraftQuestion";
             App.ReadingContext.IsReadingOnly = true;
 

--- a/RightToAskClient/UnitTests/RegistrationViewModelTests.cs
+++ b/RightToAskClient/UnitTests/RegistrationViewModelTests.cs
@@ -3,6 +3,7 @@ using RightToAskClient.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using RightToAskClient.Models;
 using Xunit;
 
 namespace UnitTests
@@ -16,13 +17,13 @@ namespace UnitTests
         public void ConstructorIsRegisteredTest()
         {
             // arrange
-            App.ReadingContext.ThisParticipant.RegistrationInfo = vTests.ValidRegistrationTest();
-            App.ReadingContext.ThisParticipant.IsRegistered = true;
+            IndividualParticipant.ProfileData.RegistrationInfo = vTests.ValidRegistrationTest();
+            IndividualParticipant.IsRegistered = true;
             App.ReadingContext.IsReadingOnly = false;
 
             // act
             RegistrationViewModel vm = new RegistrationViewModel();
-            bool validReg = App.ReadingContext.ThisParticipant.RegistrationInfo.Validate();
+            bool validReg = IndividualParticipant.ProfileData.RegistrationInfo.Validate();
 
             // assert
             Assert.True(validReg);
@@ -43,7 +44,7 @@ namespace UnitTests
         public void ConstructorNotRegisteredTest()
         {
             // arrange
-            App.ReadingContext.ThisParticipant.IsRegistered = false;
+            IndividualParticipant.IsRegistered = false;
             App.ReadingContext.IsReadingOnly = false;
 
             // act
@@ -67,7 +68,7 @@ namespace UnitTests
         public void ConstructorReadingOnlyNotRegisteredTest()
         {
             // arrange
-            App.ReadingContext.ThisParticipant.IsRegistered = false;
+            IndividualParticipant.IsRegistered = false;
             App.ReadingContext.IsReadingOnly = true;
 
             // act
@@ -92,13 +93,13 @@ namespace UnitTests
         public void ConstructorReadingOnlyIsRegisteredTest()
         {
             // arrange
-            App.ReadingContext.ThisParticipant.RegistrationInfo = vTests.ValidRegistrationTest();
-            App.ReadingContext.ThisParticipant.IsRegistered = true;
+            IndividualParticipant.ProfileData.RegistrationInfo = vTests.ValidRegistrationTest();
+            IndividualParticipant.IsRegistered = true;
             App.ReadingContext.IsReadingOnly = true;
 
             // act
             RegistrationViewModel vm = new RegistrationViewModel();
-            bool validReg = App.ReadingContext.ThisParticipant.RegistrationInfo.Validate();
+            bool validReg = IndividualParticipant.ProfileData.RegistrationInfo.Validate();
 
             // assert
             Assert.True(validReg);

--- a/RightToAskClient/UnitTests/RegistrationViewModelTests.cs
+++ b/RightToAskClient/UnitTests/RegistrationViewModelTests.cs
@@ -19,7 +19,6 @@ namespace UnitTests
             // arrange
             IndividualParticipant.ProfileData.RegistrationInfo = vTests.ValidRegistrationTest();
             IndividualParticipant.IsRegistered = true;
-            App.ReadingContext.IsReadingOnly = false;
 
             // act
             RegistrationViewModel vm = new RegistrationViewModel();
@@ -45,7 +44,6 @@ namespace UnitTests
         {
             // arrange
             IndividualParticipant.IsRegistered = false;
-            App.ReadingContext.IsReadingOnly = false;
 
             // act
             RegistrationViewModel vm = new RegistrationViewModel();
@@ -69,7 +67,6 @@ namespace UnitTests
         {
             // arrange
             IndividualParticipant.IsRegistered = false;
-            App.ReadingContext.IsReadingOnly = true;
 
             // act
             RegistrationViewModel vm = new RegistrationViewModel();
@@ -95,7 +92,6 @@ namespace UnitTests
             // arrange
             IndividualParticipant.ProfileData.RegistrationInfo = vTests.ValidRegistrationTest();
             IndividualParticipant.IsRegistered = true;
-            App.ReadingContext.IsReadingOnly = true;
 
             // act
             RegistrationViewModel vm = new RegistrationViewModel();

--- a/RightToAskClient/UnitTests/ValidationTests.cs
+++ b/RightToAskClient/UnitTests/ValidationTests.cs
@@ -107,19 +107,18 @@ namespace UnitTests
         public void ValidIndividualParticipantWithValidRegistrationTest()
         {
             // arrange
-            IndividualParticipant ip = new IndividualParticipant();
-            ip.IsRegistered = true;
+            IndividualParticipant.IsRegistered = true;
             Registration registration = new Registration(new ServerUser() { uid = "testUserId", public_key = "fakePublicKey", state = ParliamentData.StateEnum.QLD.ToString() });
-            ip.RegistrationInfo = registration;
+            IndividualParticipant.ProfileData.RegistrationInfo = registration;
 
             // act
-            bool isValid = ip.Validate();
+            bool isValid = IndividualParticipant.Validate();
 
             // assert
             Assert.True(isValid);
-            Assert.NotNull(ip.RegistrationInfo);
-            Assert.True(!string.IsNullOrEmpty(ip.RegistrationInfo.uid));
-            Assert.True(!string.IsNullOrEmpty(ip.RegistrationInfo.public_key));
+            Assert.NotNull(IndividualParticipant.ProfileData.RegistrationInfo);
+            Assert.True(!string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.uid));
+            Assert.True(!string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.public_key));
             //Assert.True(!string.IsNullOrEmpty(ip.RegistrationInfo.State)); // state is in a weird setup where it never seems to actually get set
         }
 
@@ -127,40 +126,38 @@ namespace UnitTests
         public void ValidIndividualParticipantWithInvalidRegistrationTest()
         {
             // arrange
-            IndividualParticipant ip = new IndividualParticipant();
-            ip.IsRegistered = true;
+            IndividualParticipant.IsRegistered = true;
             Registration invalidRegistration = new Registration(new ServerUser() { uid = "testUserId", state = ParliamentData.StateEnum.QLD.ToString() });
-            ip.RegistrationInfo = invalidRegistration;
+            IndividualParticipant.ProfileData.RegistrationInfo = invalidRegistration;
 
             // act
-            bool isValid = ip.Validate();
+            bool isValid = IndividualParticipant.Validate();
 
             // assert
             Assert.False(isValid);
-            Assert.NotNull(ip.RegistrationInfo);
-            Assert.True(!string.IsNullOrEmpty(ip.RegistrationInfo.uid));
-            Assert.True(string.IsNullOrEmpty(ip.RegistrationInfo.public_key));
-            //Assert.True(!string.IsNullOrEmpty(ip.RegistrationInfo.State));
+            Assert.NotNull(IndividualParticipant.ProfileData.RegistrationInfo);
+            Assert.True(!string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.uid));
+            Assert.True(string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.public_key));
+            //Assert.True(!string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.State));
         }
 
         [Fact]
         public void ValidIndividualParticipantWithoutRegistrationButKnownMPsTest()
         {
             // arrange
-            IndividualParticipant ip = new IndividualParticipant();
-            ip.IsRegistered = false;
-            ip.ElectoratesKnown = true;
+            IndividualParticipant.IsRegistered = false;
+            IndividualParticipant.ElectoratesKnown = true;
 
             // act
-            bool isValid = ip.Validate();
+            bool isValid = IndividualParticipant.Validate();
 
             // assert
             Assert.True(isValid);
-            Assert.NotNull(ip.RegistrationInfo); // always has a default registration info object created. Generates public key
-            Assert.True(ip.ElectoratesKnown);
-            Assert.False(ip.IsRegistered);
-            Assert.True(string.IsNullOrEmpty(ip.RegistrationInfo.uid));
-            Assert.True(!string.IsNullOrEmpty(ip.RegistrationInfo.public_key));
+            Assert.NotNull(IndividualParticipant.ProfileData.RegistrationInfo); // always has a default registration info object created. Generates public key
+            Assert.True(IndividualParticipant.ElectoratesKnown);
+            Assert.False(IndividualParticipant.IsRegistered);
+            Assert.True(string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.uid));
+            Assert.True(!string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.public_key));
             //Assert.True(!string.IsNullOrEmpty(ip.RegistrationInfo.State));
         }
 
@@ -168,21 +165,20 @@ namespace UnitTests
         public void InvalidIndividualParticipantTest()
         {
             // arrange
-            IndividualParticipant ip = new IndividualParticipant();
-            ip.IsRegistered = false;
-            ip.ElectoratesKnown = false;
-            ip.RegistrationInfo.StateKnown = false;
+            IndividualParticipant.IsRegistered = false;
+            IndividualParticipant.ElectoratesKnown = false;
+            IndividualParticipant.ProfileData.RegistrationInfo.StateKnown = false;
 
             // act
-            bool isValid = ip.Validate();
+            bool isValid = IndividualParticipant.Validate();
 
             // assert
             Assert.False(isValid);
-            Assert.NotNull(ip.RegistrationInfo); // always has a default registration info object created. Generates public key
-            Assert.False(ip.ElectoratesKnown);
-            Assert.False(ip.IsRegistered);
-            Assert.True(string.IsNullOrEmpty(ip.RegistrationInfo.uid));
-            Assert.True(!string.IsNullOrEmpty(ip.RegistrationInfo.public_key));
+            Assert.NotNull(IndividualParticipant.ProfileData.RegistrationInfo); // always has a default registration info object created. Generates public key
+            Assert.False(IndividualParticipant.ElectoratesKnown);
+            Assert.False(IndividualParticipant.IsRegistered);
+            Assert.True(string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.uid));
+            Assert.True(!string.IsNullOrEmpty(IndividualParticipant.ProfileData.RegistrationInfo.public_key));
         }
 
         [Fact]
@@ -432,8 +428,8 @@ namespace UnitTests
         public void ValidateClientSignedUnparsedTest()
         {
             // Arrange
-            App.ReadingContext.ThisParticipant.RegistrationInfo.uid = "TestUID10";
-            var csu = App.ReadingContext.ThisParticipant.SignMessage("fakeMessageToSend");
+            IndividualParticipant.ProfileData.RegistrationInfo.uid = "TestUID10";
+            var csu = IndividualParticipant.SignMessage("fakeMessageToSend");
 
             // Act
             bool isValid = csu.Validate();
@@ -446,8 +442,8 @@ namespace UnitTests
         public void ValidateClientSignedUnparsedFailTest()
         {
             // Arrange
-            App.ReadingContext.ThisParticipant.RegistrationInfo.uid = "TestUID10";
-            var csu = App.ReadingContext.ThisParticipant.SignMessage("fakeMessageToSend");
+            IndividualParticipant.ProfileData.RegistrationInfo.uid = "TestUID10";
+            var csu = IndividualParticipant.SignMessage("fakeMessageToSend");
             csu.message = "changedMessage";
 
             // Act

--- a/RightToAskClient/UnitTests/ValidationTests.cs
+++ b/RightToAskClient/UnitTests/ValidationTests.cs
@@ -363,11 +363,11 @@ namespace UnitTests
             address.Postcode = "2000";
 
             // act
-            Result<bool> isValid = address.SeemsValid();
+            JOSResult<bool> isValid = address.SeemsValid();
 
             // assert
-            Assert.True(isValid.Ok);
-            Assert.True(string.IsNullOrEmpty(isValid.Err));
+            Assert.True(isValid.Success);
+            // Assert.True(string.IsNullOrEmpty(isValid.Err));
             Assert.True(!string.IsNullOrEmpty(address.StreetNumberAndName));
             Assert.True(!string.IsNullOrEmpty(address.CityOrSuburb));
             Assert.True(!string.IsNullOrEmpty(address.Postcode));
@@ -381,11 +381,11 @@ namespace UnitTests
             Address address = new Address();
 
             // act
-            Result<bool> isValid = address.SeemsValid();
+            JOSResult<bool> isValid = address.SeemsValid();
 
             // assert
-            Assert.False(isValid.Ok);
-            Assert.True(!string.IsNullOrEmpty(isValid.Err));
+            Assert.True(isValid.Failure);
+            // Assert.True(!string.IsNullOrEmpty(isValid.Err));
             Assert.True(string.IsNullOrEmpty(address.StreetNumberAndName));
             Assert.True(string.IsNullOrEmpty(address.CityOrSuburb));
             Assert.True(string.IsNullOrEmpty(address.Postcode));


### PR DESCRIPTION
This PR contains a variety of data structure cleanups:
1. Getting rid of the global ReadingContext and substituting some specific static data structures for particular things.
2. Using a better Result type for internal use, which gets rid of a lot of null-related problems.