### PR TITLE
Add empty constructor for QuestionDetailPage to fix crash at end of M…

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml.cs
@@ -41,6 +41,13 @@ namespace RightToAskClient.Views
     public partial class QuestionDetailPage : ContentPage
     {
         private QuestionViewModel vm;
+
+        // This is used only in transition from the Metadata page
+        // and can be removed when it is removed.
+        public QuestionDetailPage() : this(QuestionViewModel.Instance)
+        {
+            
+        }
         public QuestionDetailPage(QuestionViewModel questionVM)
         {
             InitializeComponent();


### PR DESCRIPTION
…etadata Page. This constructor can be removed when we get rid of the Metadata page.

I did not actually remove the Metadata Page (contrary to name of branch), but hopefully it can now easily be removed.