### PR TITLE
Raise TargetSDK and minSDK levels.

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient.Android/Properties/AndroidManifest.xml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient.Android/Properties/AndroidManifest.xml
@@ -3,8 +3,8 @@
 Note that attempting to do this via AssemblyInfo.cs didn't work due to a problem
 of types (https://github.com/xamarin/xamarin-android/issues/2386)
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.RightToAskClient">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="au.org.democracydevelopers.RightToAskClient">
+	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="31" />
 	<application android:label="RightToAskClient.Android" android:networkSecurityConfig="@xml/network_security_config" android:theme="@style/MainTheme" android:fullBackupContent="@xml/auto_backup_rules" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/RightToAskClient/RightToAskClient/RightToAskClient.Android/RightToAskClient.Android.csproj
+++ b/RightToAskClient/RightToAskClient/RightToAskClient.Android/RightToAskClient.Android.csproj
@@ -22,6 +22,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Increased Android SDK target and minSDK. I *think* these are the correct settings for current Android deployment. Very happy to hear contrary opinions however, particularly from @wenpingdu. 