### PR TITLE
Report question fixes

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
@@ -760,13 +760,13 @@
     <value>This button indicates that you can answer the question by clicking here. There is no checkmark on this icon, which means that there are no other answers to this question yet. The icon is also not highlighted, which means you have not yet answered this question.</value>
   </data>
   <data name="QuestionFrameFlagButtonAccessibilityName" xml:space="preserve">
-    <value>Icon for a button that depicts a flag.</value>
+    <value>Flag button</value>
   </data>
   <data name="QuestionFrameFlagButtonAccessibilityText" xml:space="preserve">
     <value>This button indicates that you can flag or report the question by clicking here. It is currently not highlighted, which means you have not chosen to report this question.</value>
   </data>
   <data name="QuestionFrameFlagButtonAccessibilityTextRed" xml:space="preserve">
-    <value>This button indicates that you can flag or report the question by clicking here. It is currently highlighted in a redish brown color, indicating that you have already reported this question. Re-activating this button will undo and remove the report.</value>
+    <value>Reports question</value>
   </data>
   <data name="QuestionFrameShareButtonAccessibilityName" xml:space="preserve">
     <value>Share button image. Visually represented by 3 dots connected by 2 lines forming a less than sign pointing towards the left.</value>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/QuestionViewModel.cs
@@ -432,8 +432,8 @@ namespace RightToAskClient.ViewModels
                 }
                 var nextPage = new ReportQuestionPage(Question.QuestionId, ResponseRecords, new Command(() =>
                 {
-                    FlagColor = Color.Crimson;
                     Question.AlreadyReported = true;
+                    FlagColor = Color.Crimson;
                 }));
                 await Application.Current.MainPage.Navigation.PushAsync(nextPage);
             });

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDetailPage.xaml
@@ -85,6 +85,7 @@
 					<StackLayout Orientation="Horizontal" HorizontalOptions="EndAndExpand">
 						<ImageButton Source="{helpers:ImageResource RightToAskClient.Images.flag_48.png}"
 						             Padding="5" 
+						             IsEnabled="{Binding Question.AlreadyReported, Converter={StaticResource Key=cnvInvert}}"
 						             xct:IconTintColorEffect.TintColor="{Binding FlagColor}"
 						             Command="{Binding ReportCommand}"
 						             BackgroundColor="Transparent"

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDisplayCard.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDisplayCard.xaml
@@ -143,7 +143,8 @@
                          HorizontalOptions="Fill">
                 <StackLayout Orientation="Vertical"
                              VerticalOptions="CenterAndExpand"
-                             HorizontalOptions="CenterAndExpand">
+                             HorizontalOptions="CenterAndExpand"
+                             Padding="16">
                     <Image Source="{helpers:ImageResource RightToAskClient.Images.visibility_off.png}"
                            xct:IconTintColorEffect.TintColor="{AppThemeBinding Light=Black, Dark=White}"
                            WidthRequest="24"

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDisplayCard.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDisplayCard.xaml
@@ -153,13 +153,11 @@
                            FontAttributes="Bold"
                            FontSize="16"
                            HorizontalOptions="CenterAndExpand"
-                           VerticalOptions="Center"
-                           xct:SemanticEffect.Hint="{xct:Translate DisplayCardHiddenQuestionTitle}" />
+                           VerticalOptions="Center"/>
                     <Label Text="{xct:Translate DisplayCardHiddenQuestionBody}"
                            FontSize="14"
                            HorizontalOptions="CenterAndExpand"
-                           VerticalOptions="Center"
-                           xct:SemanticEffect.Hint="{xct:Translate DisplayCardHiddenQuestionBody}" />
+                           VerticalOptions="Center"/>
                 </StackLayout>
                 <BoxView Style="{StaticResource Separator}"
                          VerticalOptions="End" />

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDisplayCard.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/QuestionDisplayCard.xaml
@@ -13,7 +13,11 @@
     <ContentView.Content>
         <!-- <StackLayout> -->
         <Grid>
-            <StackLayout Style="{StaticResource AppThemeFrame}" Padding="5" VerticalOptions="FillAndExpand">
+            <StackLayout Style="{StaticResource AppThemeFrame}" 
+                         Padding="5" 
+                         VerticalOptions="FillAndExpand"
+                         IsVisible="{Binding Question.AlreadyReported, Converter={StaticResource Key=cnvInvert}}"
+            >
                 <Grid RowDefinitions="auto,auto,auto" ColumnDefinitions="2*,*,*" Padding="0" Margin="0"
                       BackgroundColor="Transparent" RowSpacing="0" ColumnSpacing="0">
                     <Grid ColumnDefinitions="*,auto" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3">
@@ -134,7 +138,6 @@
             </StackLayout>
             <!-- </StackLayout> -->
             <StackLayout BackgroundColor="{AppThemeBinding Light=White, Dark=Black}"
-                         Opacity="0.98"
                          IsVisible="{Binding Question.AlreadyReported}"
                          VerticalOptions="Fill"
                          HorizontalOptions="Fill">
@@ -150,11 +153,13 @@
                            FontAttributes="Bold"
                            FontSize="16"
                            HorizontalOptions="CenterAndExpand"
-                           VerticalOptions="Center" />
+                           VerticalOptions="Center"
+                           xct:SemanticEffect.Hint="{xct:Translate DisplayCardHiddenQuestionTitle}" />
                     <Label Text="{xct:Translate DisplayCardHiddenQuestionBody}"
                            FontSize="14"
                            HorizontalOptions="CenterAndExpand"
-                           VerticalOptions="Center" />
+                           VerticalOptions="Center"
+                           xct:SemanticEffect.Hint="{xct:Translate DisplayCardHiddenQuestionBody}" />
                 </StackLayout>
                 <BoxView Style="{StaticResource Separator}"
                          VerticalOptions="End" />

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReportQuestionPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReportQuestionPage.xaml
@@ -90,47 +90,43 @@
                         HorizontalOptions="Fill">
                 <StackLayout Orientation="Vertical"
                              VerticalOptions="FillAndExpand"
-                             HorizontalOptions="Fill">
-                    <CollectionView x:Name="QuestionList"
-                                    ItemsSource="{Binding ReasonList}"
-                                    SelectionMode="None"
-                                    VerticalOptions="FillAndExpand">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="vm:ReportReason">
+                             HorizontalOptions="Fill"
+                             BindableLayout.ItemsSource="{Binding ReasonList}">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="vm:ReportReason">
+                            <Grid VerticalOptions="StartAndExpand"
+                                  HorizontalOptions="Fill">
                                 <Grid VerticalOptions="StartAndExpand"
-                                      HorizontalOptions="Fill">
-                                    <Grid VerticalOptions="StartAndExpand"
-                                          HorizontalOptions="Fill"
-                                          Margin="16, 8, 16, 8">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="30" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-                                        <StackLayout Orientation="Vertical"
-                                                     VerticalOptions="StartAndExpand"
-                                                     HorizontalOptions="Fill"
-                                                     Grid.Column="1">
-                                            <Label Text="{Binding Title}"
-                                                   Style="{StaticResource ReportReasonTitle}" />
-                                            <Label Text="{Binding Subtitle}"
-                                                   Style="{StaticResource ReportReasonDetails}" 
-                                                   IsVisible="{Binding Subtitle.Length}"/>
-                                        </StackLayout>
-                                    </Grid>
-                                    <RadioButton GroupName="Reasons"
-                                                 CheckedChanged="RadioButton_OnCheckedChanged"
-                                                 Value="{Binding ID}"
-                                                 IsChecked="{Binding Selected}"
-                                                 xct:SemanticEffect.Hint="{Binding Subtitle}"
-                                                 xct:SemanticEffect.Description="{Binding Title}"
-                                                 VerticalOptions="Fill"
+                                      HorizontalOptions="Fill"
+                                      Margin="16, 8, 16, 8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="30" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <StackLayout Orientation="Vertical"
+                                                 VerticalOptions="StartAndExpand"
                                                  HorizontalOptions="Fill"
-                                                 ControlTemplate="{StaticResource ThemeRadioTemplate}"
-                                                 Content=" "/>
+                                                 Grid.Column="1">
+                                        <Label Text="{Binding Title}"
+                                               Style="{StaticResource ReportReasonTitle}" />
+                                        <Label Text="{Binding Subtitle}"
+                                               Style="{StaticResource ReportReasonDetails}"
+                                               IsVisible="{Binding Subtitle.Length}" />
+                                    </StackLayout>
                                 </Grid>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
+                                <RadioButton GroupName="Reasons"
+                                             CheckedChanged="RadioButton_OnCheckedChanged"
+                                             Value="{Binding ID}"
+                                             IsChecked="{Binding Selected}"
+                                             xct:SemanticEffect.Hint="{Binding Subtitle}"
+                                             xct:SemanticEffect.Description="{Binding Title}"
+                                             VerticalOptions="Fill"
+                                             HorizontalOptions="Fill"
+                                             ControlTemplate="{StaticResource ThemeRadioTemplate}"
+                                             Content=" " />
+                            </Grid>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
                 </StackLayout>
             </ScrollView>
             <BoxView Style="{StaticResource ButtonSeparator}" />
@@ -141,10 +137,10 @@
                 <Button Text="{xct:Translate ReportSubmit}"
                         Command="{Binding ReportCommand}"
                         xct:SemanticEffect.Hint="{xct:Translate ReportSubmitHint}"
-                        xct:SemanticEffect.Description="{xct:Translate ReportSubmit}" 
+                        xct:SemanticEffect.Description="{xct:Translate ReportSubmit}"
                         Style="{StaticResource NormalButton}"
-                        CornerRadius="5" 
-                        IsEnabled="{Binding IsSelected}"/>
+                        CornerRadius="5"
+                        IsEnabled="{Binding IsSelected}" />
             </StackLayout>
         </StackLayout>
     </ContentPage.Content>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReportQuestionPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/ReportQuestionPage.xaml
@@ -18,7 +18,7 @@
         <ResourceDictionary>
             <ControlTemplate x:Key="ThemeRadioTemplate">
                 <Frame x:Name="CheckFrame"
-                       Margin="16, 16, 16, 0"
+                       Margin="16, 8, 16, 8"
                        Padding="0"
                        HasShadow="False"
                        HorizontalOptions="Fill"
@@ -101,7 +101,7 @@
                                       HorizontalOptions="Fill">
                                     <Grid VerticalOptions="StartAndExpand"
                                           HorizontalOptions="Fill"
-                                          Margin="16, 16, 16, 0">
+                                          Margin="16, 8, 16, 8">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="30" />
                                             <ColumnDefinition Width="*" />


### PR DESCRIPTION
- [x] Balance top and bottom padding in report reason list to reduce fatfinger issue
- [x] Remove the blank space area at the bottom of the report question reason list
- [x] Hidden question text is not being read by screen reader when a question has been reported
- [x] Screen reader reads the report button as "already reported" even though the question hasn't been reported
- [x] Not allow user to go inside detailed question view when said question has been reported