### PR TITLE
Blank server results.

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReportQuestionViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReportQuestionViewModel.cs
@@ -174,7 +174,7 @@ namespace RightToAskClient.ViewModels
             };
             var httpResponse = await RTAClient.SendReportQuestion(reportQuestion,
                 IndividualParticipant.getInstance().ProfileData.RegistrationInfo.uid);
-            (bool isValid, string errorMessage, string _) = RTAClient.ValidateHttpResponse(httpResponse, "Report question");  
+            (bool isValid, string errorMessage) = RTAClient.ValidateHttpResponse(httpResponse, "Report question");  
             if(!isValid) 
             {
                 var error =  "Error Reporting question: " + errorMessage;


### PR DESCRIPTION
Correct error handling for the case when the server returns a non-data result type.

This is necessary for things that don't go on the bulletin board - at the moment, flags and unencrypted votes.