### PR TITLE
[191][123] Terms and Conditions popup fix

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
@@ -2324,5 +2324,17 @@ namespace RightToAskClient.Resx {
                 return ResourceManager.GetString("TermsAndConditionsMarkdown", resourceCulture);
             }
         }
+        
+        internal static string TermsAndConditionsHelpTextAndroid {
+            get {
+                return ResourceManager.GetString("TermsAndConditionsHelpTextAndroid", resourceCulture);
+            }
+        }
+        
+        internal static string TermsAndConditionsHelpTextIOS {
+            get {
+                return ResourceManager.GetString("TermsAndConditionsHelpTextIOS", resourceCulture);
+            }
+        }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
@@ -2199,36 +2199,6 @@ namespace RightToAskClient.Resx {
             }
         }
         
-        internal static string TermAndConditionPlainText {
-            get {
-                return ResourceManager.GetString("TermAndConditionPlainText", resourceCulture);
-            }
-        }
-        
-        internal static string TermAndConditionPlainText2 {
-            get {
-                return ResourceManager.GetString("TermAndConditionPlainText2", resourceCulture);
-            }
-        }
-        
-        internal static string PrivacyPolicy {
-            get {
-                return ResourceManager.GetString("PrivacyPolicy", resourceCulture);
-            }
-        }
-        
-        internal static string and {
-            get {
-                return ResourceManager.GetString("and", resourceCulture);
-            }
-        }
-        
-        internal static string TermAndCondition {
-            get {
-                return ResourceManager.GetString("TermAndCondition", resourceCulture);
-            }
-        }
-        
         internal static string AgreeAndContinueButton {
             get {
                 return ResourceManager.GetString("AgreeAndContinueButton", resourceCulture);

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.Designer.cs
@@ -2318,5 +2318,11 @@ namespace RightToAskClient.Resx {
                 return ResourceManager.GetString("AllElectorateState", resourceCulture);
             }
         }
+        
+        internal static string TermsAndConditionsMarkdown {
+            get {
+                return ResourceManager.GetString("TermsAndConditionsMarkdown", resourceCulture);
+            }
+        }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
@@ -1247,21 +1247,6 @@ We are still learning about how people use Right To Ask. These rules may change 
   <data name="SharingElectorateInfoPickerTitle" xml:space="preserve">
     <value>Electorate info on your profile</value>
   </data>
-  <data name="TermAndConditionPlainText" xml:space="preserve">
-  <value>By tapping “Agree and continue”, </value>
-  </data>
-    <data name="TermAndConditionPlainText2" xml:space="preserve">
-  <value>you agree to our</value>
-  </data>
-    <data name="PrivacyPolicy" xml:space="preserve">
-  <value>Privacy Policy</value>
-  </data>
-    <data name="and" xml:space="preserve">
-  <value>and</value>
-  </data>
-    <data name="TermAndCondition" xml:space="preserve">
-  <value>Terms and Conditions.</value>
-  </data>
     <data name="AgreeAndContinueButton" xml:space="preserve">
   <value>Agree and continue</value>
   </data>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
@@ -1307,4 +1307,7 @@ We are still learning about how people use Right To Ask. These rules may change 
   <data name="AllElectorateState" xml:space="preserve">
   <value>Federal Electorate, State Electorate and state</value>
   </data>
+  <data name="TermsAndConditionsMarkdown" xml:space="preserve">
+  <value>By tapping "Agree and Continue", you agree to our [Privacy Policy](https://righttoask.democracydevelopers.org.au/privacy-policy/) and [Terms and Conditions](https://righttoask.democracydevelopers.org.au/).</value>
+  </data>
 </root>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Resx/AppResources.resx
@@ -1310,4 +1310,10 @@ We are still learning about how people use Right To Ask. These rules may change 
   <data name="TermsAndConditionsMarkdown" xml:space="preserve">
   <value>By tapping "Agree and Continue", you agree to our [Privacy Policy](https://righttoask.democracydevelopers.org.au/privacy-policy/) and [Terms and Conditions](https://righttoask.democracydevelopers.org.au/).</value>
   </data>
+  <data name="TermsAndConditionsHelpTextAndroid" xml:space="preserve">
+  <value>By tapping Agree and Continue, you agree to our Privacy Policy and Terms and Conditions, double tap to activate to read the Privacy Policy or Terms and Conditions</value>
+  </data>
+  <data name="TermsAndConditionsHelpTextIOS" xml:space="preserve">
+  <value>By tapping Agree and Continue, you agree to our Privacy Policy, link, and Terms and Conditions, link</value>
+  </data>
 </root>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/BaseViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/BaseViewModel.cs
@@ -27,11 +27,7 @@ namespace RightToAskClient.ViewModels
             InfoPopupCommand = new AsyncCommand(async () =>
             {
                 //Page.Navigation.ShowPopup(new InfoPopup());
-                // var popup = new InfoPopup(PopupHeaderText,PopupLabelText, AppResources.OKText);
-                // _ = await Application.Current.MainPage.Navigation.ShowPopupAsync(popup);
-
-
-                var popup = new TermAndConditionPopup();
+                var popup = new InfoPopup(PopupHeaderText,PopupLabelText, AppResources.OKText);
                 _ = await Application.Current.MainPage.Navigation.ShowPopupAsync(popup);
             });
             TCCommand = new AsyncCommand(async () =>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/BaseViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/BaseViewModel.cs
@@ -16,7 +16,8 @@ namespace RightToAskClient.ViewModels
             PopupLabelText = "TestText";
             HomeButtonCommand = new AsyncCommand(async () =>
             {
-                var popup = new TwoButtonPopup(AppResources.GoHomePopupTitle, AppResources.GoHomePopupText, AppResources.CancelButtonText, AppResources.GoHomeButtonText, false);
+                var popup = new TwoButtonPopup(AppResources.GoHomePopupTitle, AppResources.GoHomePopupText,
+                    AppResources.CancelButtonText, AppResources.GoHomeButtonText, false);
                 var popupResult = await Application.Current.MainPage.Navigation.ShowPopupAsync(popup);
                 if (popup.HasApproved(popupResult))
                 {
@@ -26,7 +27,11 @@ namespace RightToAskClient.ViewModels
             InfoPopupCommand = new AsyncCommand(async () =>
             {
                 //Page.Navigation.ShowPopup(new InfoPopup());
-                var popup = new InfoPopup(PopupHeaderText,PopupLabelText, AppResources.OKText);
+                // var popup = new InfoPopup(PopupHeaderText,PopupLabelText, AppResources.OKText);
+                // _ = await Application.Current.MainPage.Navigation.ShowPopupAsync(popup);
+
+
+                var popup = new TermAndConditionPopup();
                 _ = await Application.Current.MainPage.Navigation.ShowPopupAsync(popup);
             });
             TCCommand = new AsyncCommand(async () =>
@@ -37,6 +42,7 @@ namespace RightToAskClient.ViewModels
         }
 
         private string _title = string.Empty;
+
         public string Title
         {
             get => _title;
@@ -44,13 +50,15 @@ namespace RightToAskClient.ViewModels
         }
 
         private string _popupHeaderText = "";
+
         public string PopupHeaderText
         {
             get => _popupHeaderText;
             set => SetProperty(ref _popupHeaderText, value);
         }
-        
+
         private string _popupLabelText = "";
+
         public string PopupLabelText
         {
             get => _popupLabelText;
@@ -58,6 +66,7 @@ namespace RightToAskClient.ViewModels
         }
 
         private string _reportLabelText = "";
+
         public string ReportLabelText
         {
             get => _reportLabelText;

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml
@@ -3,8 +3,6 @@
 <xct:Popup xmlns="http://xamarin.com/schemas/2014/forms"
            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
            xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
-           xmlns:local="clr-namespace:RightToAskClient"
-           xmlns:helpers="clr-namespace:RightToAskClient.Helpers;assembly=RightToAskClient"
            x:Class="RightToAskClient.Views.Popups.TermAndConditionPopup"
            Size="300,160"
            IsLightDismissEnabled="False"

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
+
 <xct:Popup xmlns="http://xamarin.com/schemas/2014/forms"
-           xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"    
+           xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
            xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
            xmlns:local="clr-namespace:RightToAskClient"
            xmlns:helpers="clr-namespace:RightToAskClient.Helpers;assembly=RightToAskClient"
@@ -9,77 +10,28 @@
            IsLightDismissEnabled="False"
            Color="Transparent">
     <Frame CornerRadius="5" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" Padding="0"
-               BackgroundColor="{AppThemeBinding Light={StaticResource WindowBackgroundColor}, Dark={StaticResource PopupDarkModeBgColor}}">
+           BackgroundColor="{AppThemeBinding Light={StaticResource WindowBackgroundColor}, Dark={StaticResource PopupDarkModeBgColor}}">
         <StackLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" BackgroundColor="Transparent">
-            <OnPlatform x:TypeArguments="View">
-                <On Platform="iOS">
-            <Label  VerticalOptions="StartAndExpand"
-                    HorizontalOptions="Center" HorizontalTextAlignment="Center" Style="{StaticResource PopupText}" Margin="24,24,24,0">
-                <Label.FormattedText>
-                    <FormattedString>
-                        <Span Text="{xct:Translate TermAndConditionPlainText}"/>
-                        <Span Text="{xct:Translate TermAndConditionPlainText2}"/>
-                        <Span Text=" "/>
-                        <Span Text="{xct:Translate PrivacyPolicy}"
-                              TextColor="{AppThemeBinding Light={StaticResource UrlTextColorLightMode}, Dark={StaticResource UrlTextColorDarkMode}}"
-                              TextDecorations="Underline">
-                            <Span.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="PrivacyPolicy_OnTapped"
-                                                      xct:SemanticEffect.Hint="{xct:Translate TCPolicyHint}"
-                                                      xct:SemanticEffect.Description="{xct:Translate PrivacyPolicy}"/>
-                            </Span.GestureRecognizers>
-                        </Span>
-                        <Span Text=" "/>
-                        <Span Text="{xct:Translate and}"/>
-                        <Span Text=" "/>
-                        <Span Text="{xct:Translate TermAndCondition}"
-                              TextColor="{AppThemeBinding Light={StaticResource UrlTextColorLightMode}, Dark={StaticResource UrlTextColorDarkMode}}"
-                              TextDecorations="Underline">
-                            <Span.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="TermAndCondition_OnTapped"
-                                                      xct:SemanticEffect.Hint="{xct:Translate TCHint}"
-                                                      xct:SemanticEffect.Description="{xct:Translate TermAndCondition}"/>
-                            </Span.GestureRecognizers>
-                        </Span>
-                    </FormattedString>
-                </Label.FormattedText>
-            </Label>
-                </On>
-            
-            <On Platform="Android">
-                    <StackLayout HorizontalOptions="Center" Margin="24,16,24,16" Orientation="Vertical">
-                        <Label Text="{xct:Translate TermAndConditionPlainText}"/>
-                        <StackLayout HorizontalOptions="Center" Orientation="Horizontal">
-                            <Label Text="{xct:Translate TermAndConditionPlainText2}"/>
-                            <Button Text="{xct:Translate PrivacyPolicy}" BackgroundColor="Transparent"
-                                    TextColor="{AppThemeBinding Light={StaticResource UrlTextColorLightMode}, Dark={StaticResource UrlTextColorDarkMode}}"
-                                    Clicked="PrivacyPolicy_OnTapped"
-                                    xct:SemanticEffect.Hint="{xct:Translate TCPolicyHint}"
-                                    xct:SemanticEffect.Description="{xct:Translate PrivacyPolicy}"/>
-                            <Label Text="{xct:Translate and}"/>
-                        </StackLayout>
-                        <StackLayout HorizontalOptions="Center" Orientation="Horizontal">
-                            <Button Text="{xct:Translate TermAndCondition}" BackgroundColor="Transparent"
-                                    TextColor="{AppThemeBinding Light={StaticResource UrlTextColorLightMode}, Dark={StaticResource UrlTextColorDarkMode}}"
-                                    Clicked="TermAndCondition_OnTapped"
-                                    xct:SemanticEffect.Hint="{xct:Translate TCHint}"
-                                    xct:SemanticEffect.Description="{xct:Translate TermAndCondition}"/>
-                        </StackLayout>
-                    </StackLayout>
-                    
-                </On>
-            </OnPlatform>
-            
-            <StackLayout Padding="0,1,0,0" BackgroundColor="{AppThemeBinding Light={StaticResource FadedButtonColor}, Dark={StaticResource SeparatorDarkModeColor}}">
-                   <!--Acknowledge/Dismiss Button Bottom Right-->
-                   <StackLayout BackgroundColor="{AppThemeBinding Light=White, Dark={StaticResource PopupDarkModeBgColor}}">
-                   <Button Text="{xct:Translate AgreeAndContinueButton}" HorizontalOptions="Center" VerticalOptions="End" Clicked="okButton_Clicked" 
-                           xct:SemanticEffect.Hint="{xct:Translate TCContinueButtonHint}"
-                           xct:SemanticEffect.Description="{xct:Translate AgreeAndContinueButton}"
-                           Style="{StaticResource PopupOKButton}" BackgroundColor="Transparent"/>
-                   </StackLayout>
+
+            <StackLayout Orientation="Vertical"
+                         VerticalOptions="CenterAndExpand"
+                         HorizontalOptions="CenterAndExpand"
+                         x:Name="MarkdownView"
+                         Margin="16, 0">
             </StackLayout>
-            
+
+            <StackLayout Padding="0,1,0,0"
+                         BackgroundColor="{AppThemeBinding Light={StaticResource FadedButtonColor}, Dark={StaticResource SeparatorDarkModeColor}}">
+                <!--Acknowledge/Dismiss Button Bottom Right-->
+                <StackLayout
+                    BackgroundColor="{AppThemeBinding Light=White, Dark={StaticResource PopupDarkModeBgColor}}">
+                    <Button Text="{xct:Translate AgreeAndContinueButton}" HorizontalOptions="Center"
+                            VerticalOptions="End" Clicked="okButton_Clicked"
+                            xct:SemanticEffect.Hint="{xct:Translate TCContinueButtonHint}"
+                            xct:SemanticEffect.Description="{xct:Translate AgreeAndContinueButton}"
+                            Style="{StaticResource PopupOKButton}" BackgroundColor="Transparent" />
+                </StackLayout>
+            </StackLayout>
         </StackLayout>
     </Frame>
 </xct:Popup>

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml
@@ -24,6 +24,7 @@
                 <StackLayout
                     BackgroundColor="{AppThemeBinding Light=White, Dark={StaticResource PopupDarkModeBgColor}}">
                     <Button Text="{xct:Translate AgreeAndContinueButton}" HorizontalOptions="Center"
+                            FontSize="Small"
                             VerticalOptions="End" Clicked="okButton_Clicked"
                             xct:SemanticEffect.Hint="{xct:Translate TCContinueButtonHint}"
                             xct:SemanticEffect.Description="{xct:Translate AgreeAndContinueButton}"

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml.cs
@@ -1,7 +1,10 @@
 using System;
 using RightToAskClient.Helpers;
+using RightToAskClient.Resx;
+using Xam.Forms.Markdown;
 using Xamarin.CommunityToolkit.UI.Views;
 using Xamarin.Essentials;
+using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace RightToAskClient.Views.Popups
@@ -12,8 +15,26 @@ namespace RightToAskClient.Views.Popups
         public TermAndConditionPopup()
         {
             InitializeComponent();
+
+            var lightTheme = new LightMarkdownTheme();
+            lightTheme.Paragraph.FontSize = (float)Device.GetNamedSize(NamedSize.Small, typeof(Label));
+            lightTheme.BackgroundColor = Color.Transparent;
+            lightTheme.Link.ForegroundColor = (Color)Application.Current.Resources["UrlTextColorLightMode"];
+
+            var darkTheme = new DarkMarkdownTheme();
+            darkTheme.Paragraph.FontSize = (float)Device.GetNamedSize(NamedSize.Small, typeof(Label));
+            darkTheme.BackgroundColor = Color.Transparent;
+            darkTheme.Link.ForegroundColor = (Color)Application.Current.Resources["UrlTextColorDarkMode"];
+
+            var mdView = new MarkdownView();
+
+            mdView.Markdown = AppResources.TermsAndConditionsMarkdown;
+            mdView.RelativeUrlHost = "";
+            mdView.SetOnAppTheme<MarkdownTheme>(Xam.Forms.Markdown.MarkdownView.ThemeProperty, lightTheme, darkTheme);
+
+            MarkdownView.Children.Add(new ScrollView() { Content = mdView });
         }
-        
+
         private void okButton_Clicked(object sender, EventArgs e)
         {
             XamarinPreferences.shared.Set(Constants.ShowFirstTimeReadingPopup, false);
@@ -22,12 +43,14 @@ namespace RightToAskClient.Views.Popups
 
         private async void PrivacyPolicy_OnTapped(object sender, EventArgs e)
         {
-            await Browser.OpenAsync("https://righttoask.democracydevelopers.org.au/privacy-policy/", BrowserLaunchMode.SystemPreferred);
+            await Browser.OpenAsync("https://righttoask.democracydevelopers.org.au/privacy-policy/",
+                BrowserLaunchMode.SystemPreferred);
         }
-        
+
         private async void TermAndCondition_OnTapped(object sender, EventArgs e)
         {
-            await Browser.OpenAsync("https://righttoask.democracydevelopers.org.au/", BrowserLaunchMode.SystemPreferred);
+            await Browser.OpenAsync("https://righttoask.democracydevelopers.org.au/",
+                BrowserLaunchMode.SystemPreferred);
         }
     }
 }

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml.cs
@@ -30,8 +30,16 @@ namespace RightToAskClient.Views.Popups
 
             mdView.Markdown = AppResources.TermsAndConditionsMarkdown;
             mdView.RelativeUrlHost = "";
-            AutomationProperties.SetHelpText(mdView,
-                "By tapping Agree and Continue, you agree to our Privacy Policy and Terms and Conditions, double tap to activate read the Privacy Policy or Terms and Conditions");
+            AutomationProperties.SetIsInAccessibleTree(mdView, true);
+            if (DeviceInfo.Platform == DevicePlatform.Android)
+            {
+                AutomationProperties.SetHelpText(mdView, AppResources.TermsAndConditionsHelpTextAndroid);
+            }
+            else if (DeviceInfo.Platform == DevicePlatform.iOS)
+            {
+                AutomationProperties.SetHelpText(mdView, AppResources.TermsAndConditionsHelpTextIOS);
+            }
+
             mdView.SetOnAppTheme<MarkdownTheme>(Xam.Forms.Markdown.MarkdownView.ThemeProperty, lightTheme, darkTheme);
 
             MarkdownView.Children.Add(new ScrollView() { Content = mdView });

--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/Popups/TermAndConditionPopup.xaml.cs
@@ -30,6 +30,8 @@ namespace RightToAskClient.Views.Popups
 
             mdView.Markdown = AppResources.TermsAndConditionsMarkdown;
             mdView.RelativeUrlHost = "";
+            AutomationProperties.SetHelpText(mdView,
+                "By tapping Agree and Continue, you agree to our Privacy Policy and Terms and Conditions, double tap to activate read the Privacy Policy or Terms and Conditions");
             mdView.SetOnAppTheme<MarkdownTheme>(Xam.Forms.Markdown.MarkdownView.ThemeProperty, lightTheme, darkTheme);
 
             MarkdownView.Children.Add(new ScrollView() { Content = mdView });


### PR DESCRIPTION
https://trello.com/c/5dlBRDDj/123-display-tc-pop-up-when-the-app-is-opened-for-the-first-time-2
https://trello.com/c/vk8IZniJ/191-pp-tc-link-is-not-available-for-voiceover-voice-control

- used markdown for the T&C popup content
- ensure that the agree and continue button is still shown when font size is enlarged
- voiceover in IOS is able to read the content
- scale the agree and continue button

# Android
## Normal
|light|dark|
|-|-|
|![Screen Shot 2023-02-20 at 3 06 14 pm](https://user-images.githubusercontent.com/49172978/220007196-0ade3bef-58f8-47a3-b37b-fc124b5bb07f.png)|![Screen Shot 2023-02-20 at 3 05 58 pm](https://user-images.githubusercontent.com/49172978/220007209-cd8bab87-32d8-4a42-b67b-28913cf7733e.png)|


## Large font size
![Screen Shot 2023-02-20 at 1 32 51 pm](https://user-images.githubusercontent.com/49172978/220003103-453f3611-4d59-4b59-bada-ff162b81752d.png)

# iOS
## Normal


|light|dark|
|-|-|
|![Screen Shot 2023-02-20 at 2 53 30 pm](https://user-images.githubusercontent.com/49172978/220005869-c9871105-901f-46c5-ba1a-27b2d3ac606b.png)|![Screen Shot 2023-02-20 at 3 09 08 pm](https://user-images.githubusercontent.com/49172978/220007504-3bd5b9d2-b2d9-4be7-9d1d-2ad19e8c6a05.png)|

## Voiceover
![Screen Shot 2023-02-20 at 2 54 46 pm](https://user-images.githubusercontent.com/49172978/220005875-92eb41a2-b754-4564-8ed0-0859266615a1.png)

## Large font size
![Screen Shot 2023-02-20 at 12 35 44 pm](https://user-images.githubusercontent.com/49172978/220003119-1133d878-108e-40d0-b175-edc8cd168341.png)
