### PR TITLE
[231] Rename 'Proceed to question' button to 'Next' and restyle

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient/Views/WriteQuestionPage.xaml
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/Views/WriteQuestionPage.xaml
@@ -135,27 +135,31 @@
                             </ImageButton>
                         </StackLayout>
                     </Grid>
-                    <FlexLayout AlignItems="Center" JustifyContent="SpaceBetween" HorizontalOptions="CenterAndExpand" Direction="Row" Margin="16,0,16,12">
-                        <Label Text="0/280" 
-                               Style="{StaticResource EditorTextNumber}" 
-                               x:Name="EditorTextNumber" />
+
+                    <FlexLayout AlignItems="Center" JustifyContent="SpaceBetween" Margin="16,0,16,12">
                         <Button Text="Return home"
-                                Style="{StaticResource EditorProceed}" 
+                                Style="{StaticResource EditorProceed}"
                                 Command="{Binding BackCommand}"
                                 xct:SemanticEffect.Hint="{xct:Translate ReturnHomeHint}"
-                                xct:SemanticEffect.Description="{xct:Translate ReturnHomeButtonDescription}"/>
-                        <StackLayout VerticalOptions="CenterAndExpand"
-                                     HorizontalOptions="CenterAndExpand">
-                            <BoxView BackgroundColor="{StaticResource FadedButtonColor}" 
-                                     VerticalOptions="CenterAndExpand" 
-                                     HeightRequest="24"
-                                     WidthRequest="1" />
+                                xct:SemanticEffect.Description="{xct:Translate ReturnHomeButtonDescription}" />
+
+                        <StackLayout Margin="0" HorizontalOptions="End" Orientation="Horizontal">
+                            <Label Text="0/280"
+                                   Padding="8, 0"
+                                   Style="{StaticResource EditorTextNumber}"
+                                   x:Name="EditorTextNumber"
+                                   VerticalOptions="Center" />
+                            <BoxView Color="{StaticResource FadedButtonColor}"
+                                     VerticalOptions="CenterAndExpand"
+                                     HeightRequest="22"
+                                     WidthRequest="2" />
+                            <Button Text="Next" x:Name="EditorProceedButton"
+                                    Padding="8, 0, 16, 0"
+                                    Style="{StaticResource EditorProceed}"
+                                    Command="{Binding ProceedButtonCommand}"
+                                    xct:SemanticEffect.Hint="{xct:Translate EditorProceedHint}"
+                                    xct:SemanticEffect.Description="{xct:Translate EditorProceedButtonDescription}" />
                         </StackLayout>
-                        <Button Text="Proceed with this question" x:Name="EditorProceedButton"
-                                Style="{StaticResource EditorProceed}" 
-                                Command="{Binding ProceedButtonCommand}"
-                                xct:SemanticEffect.Hint="{xct:Translate EditorProceedHint}"
-                                xct:SemanticEffect.Description="{xct:Translate EditorProceedButtonDescription}"/>
                     </FlexLayout>
                 </StackLayout>
             </StackLayout>


### PR DESCRIPTION
Story 231 - Rename "Proceed with this question" button to "Next" button
[x] Rename 'Proceed to question' button to 'Next' and restyle
[x] Update style to match Figma design as it did not look great once text was changed