### PR TITLE
Redo on start

### DIFF
--- a/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/App.xaml.cs
@@ -43,21 +43,25 @@ namespace RightToAskClient
         protected override async void OnStart()
         {
             // ResetAppData(); // Toggle this line in and out as needed instead of resetting the emulator every time
-            
-            // We do not use these values, but for reasons I don't fully understand, the return value seemed to make the
-            // async code actually execute.
-            var MPInitSuccess = await ParliamentData.MPAndOtherData.TryInit();
-            var CommitteeInitSuccess = await CommitteesAndHearingsData.CommitteesData.TryInitialisingFromServer();
-            var signingKeyRetrieved = await ClientSignatureGenerationService.Init();
-            
-            IndividualParticipant.getInstance().Init();
-            
-            if(IndividualParticipant.getInstance().ProfileData.RegistrationInfo.ElectoratesKnown) 
-            {
-                FilterChoices.NeedToUpdateMyMpLists(this);
-            }
-            Current.On<Xamarin.Forms.PlatformConfiguration.Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize);
 
+            Task.Run(async () =>
+            {
+                // We do not use these values, but for reasons I don't fully understand, the return value seemed to make the
+                // async code actually execute.
+                var MPInitSuccess = await ParliamentData.MPAndOtherData.TryInit();
+                var CommitteeInitSuccess = await CommitteesAndHearingsData.CommitteesData.TryInitialisingFromServer();
+                var signingKeyRetrieved = await ClientSignatureGenerationService.Init();
+
+                IndividualParticipant.getInstance().Init();
+
+                if (IndividualParticipant.getInstance().ProfileData.RegistrationInfo.ElectoratesKnown)
+                {
+                    FilterChoices.NeedToUpdateMyMpLists(this);
+                }
+            });
+
+            Current.On<Xamarin.Forms.PlatformConfiguration.Android>()
+                .UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize);
         }
 
         protected override void OnSleep()

--- a/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
+++ b/RightToAskClient/RightToAskClient/RightToAskClient/ViewModels/ReadingPageViewModel.cs
@@ -140,11 +140,16 @@ namespace RightToAskClient.ViewModels
             // of questions from various versions of questionsToDisplay List.
             // I don't *think* this will cause a lock because QuestionsToDisplay
             // ought to be able to be cleared and added to in any order.
-            RefreshCommand = new AsyncCommand(async () =>
+            RefreshCommand = new AsyncCommand(() =>
             {
-                var questionsToDisplayList = await LoadQuestions();
-                doQuestionDisplayRefresh(questionsToDisplayList);
-                IsRefreshing = false;
+                Task.Run(async () =>
+                {
+
+                    var questionsToDisplayList = await LoadQuestions();
+                    doQuestionDisplayRefresh(questionsToDisplayList);
+                    IsRefreshing = false;
+                });
+                return Task.CompletedTask;
             });
             DraftCommand = new AsyncCommand(async () =>
             {


### PR DESCRIPTION
An effort to deal with start-up bugs by executing slow code (such as server requests) in non-UI threads.